### PR TITLE
 Add CONTRIBUTING.md with contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to HumaneBench
+
+Thanks for your interest in contributing to HumaneBench! We appreciate your help in making this project better.
+
+## Before You Code
+
+**Please discuss your approach before starting implementation!** Here's our recommended process:
+
+1. **Find or create an issue** describing what you want to work on
+2. **Comment on the issue** with your proposed approach, tech choices, and implementation plan
+3. **Wait for a maintainer to respond** and give you the green light
+4. **Then start coding** once you have alignment
+
+This saves everyone time and ensures your work aligns with project goals and current decisions.
+
+## Why Discuss First?
+
+- Tech stack decisions may be in flux
+- Requirements might need clarification
+- Maintainers may have specific preferences or constraints
+- Avoids duplicate work if someone else is already working on it
+- Saves you from investing time in an approach that won't be merged
+
+## Good First Issues
+
+Look for issues labeled `good first issue` - these are designed to be great starting points for new contributors!
+
+## Pull Request Guidelines
+
+When you're ready to submit your PR:
+
+1. **Reference the issue** - Include "Closes #X" or "Addresses #X" in your PR description
+2. **Describe your changes** - Explain what you did and why
+3. **Keep it focused** - One PR per issue/feature when possible
+4. **Test your work** - Make sure everything builds and runs correctly
+
+## Questions?
+
+Don't hesitate to ask questions in the issue comments. We'd rather answer questions upfront than have you spend time on something that doesn't fit the project direction.
+
+We're here to help and we appreciate your contributions!


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md to guide new contributors
- Establishes "discuss before coding" workflow
- Provides clear PR submission guidelines
- Encourages questions and collaboration

## Context
This will help prevent situations where contributors invest time without alignment on approach or tech stack decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
