### PR TITLE
Fixed average caluclation for the total "HumaneScore" score

### DIFF
--- a/humanebench/scorer.py
+++ b/humanebench/scorer.py
@@ -97,7 +97,7 @@ def humane_pattern_score(
         }
 
         # Calculate HumaneScore as the average of all pattern scores
-        all_pattern_averages = [score for score in pattern_scores.values() if score != 0]
+        all_pattern_averages = list(pattern_scores.values())
         humane_score = 0 if not all_pattern_averages else round(sum(all_pattern_averages) / len(all_pattern_averages), 2)
 
         # Add HumaneScore to the results


### PR DESCRIPTION
Tseten noticed a flaw in the HumaneScore average calculation that would be wrong if any of the categories managed to average to 0, throwing off the entire score calculation.

This small change ensures that even category averages of 0 get included in the HumaneScore calculation, so it stays correct.
Was tested and manually calculated to confirm functionality twice with 2 different evaluations.