### PR TITLE
Add model_scores.json exporter for website publishing

### DIFF
--- a/figures/scoregrid_bad_persona.svg
+++ b/figures/scoregrid_bad_persona.svg
@@ -13,24 +13,24 @@
   <text x="328.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.32</text>
   <rect x="372" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="enable-meaningful-choices" data-score="0.93" />
   <text x="412.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
-  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.94" />
+  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.94" />
   <text x="496.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
+  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
   <text x="580.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
   <rect x="624" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="foster-healthy-relationships" data-score="0.91" />
   <text x="664.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="708" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
+  <rect x="708" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(107, 199, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.70" />
+  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(106, 199, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.70" />
   <text x="832.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.70</text>
-  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.92" />
-  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.91" />
+  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
   <text x="0" y="49.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5.1</text>
-  <rect x="180" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.82" />
-  <text x="220.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
+  <rect x="180" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.83" />
+  <text x="220.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <rect x="288" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(190, 214, 43)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="respect-user-attention" data-score="0.11" />
   <text x="328.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.11</text>
-  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="enable-meaningful-choices" data-score="0.94" />
+  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="enable-meaningful-choices" data-score="0.94" />
   <text x="412.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
   <rect x="456" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="enhance-human-capabilities" data-score="0.98" />
   <text x="496.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
@@ -38,94 +38,94 @@
   <text x="580.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
   <rect x="624" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="foster-healthy-relationships" data-score="0.90" />
   <text x="664.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <rect x="708" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
+  <rect x="708" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
   <text x="748.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
   <rect x="792" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="be-transparent-and-honest" data-score="0.78" />
   <text x="832.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
   <rect x="876" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-5.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.95" />
   <text x="916.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
   <text x="0" y="83.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4.5</text>
-  <rect x="180" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.77" />
+  <rect x="180" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(96, 197, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.77" />
   <text x="220.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
   <rect x="288" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(105, 199, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="respect-user-attention" data-score="0.71" />
   <text x="328.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.71</text>
   <rect x="372" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(112, 200, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="enable-meaningful-choices" data-score="0.66" />
   <text x="412.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
-  <rect x="456" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="enhance-human-capabilities" data-score="0.79" />
+  <rect x="456" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="enhance-human-capabilities" data-score="0.79" />
   <text x="496.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
   <rect x="540" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="protect-dignity-and-safety" data-score="0.83" />
   <text x="580.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <rect x="624" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="foster-healthy-relationships" data-score="0.80" />
   <text x="664.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
-  <rect x="708" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.89" />
+  <rect x="708" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.89" />
   <text x="748.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
   <rect x="792" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="be-transparent-and-honest" data-score="0.65" />
   <text x="832.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
-  <rect x="876" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.82" />
-  <text x="916.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
+  <rect x="876" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.84" />
+  <text x="916.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
   <text x="0" y="117.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Opus 4.1</text>
   <rect x="180" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(112, 200, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="HumaneScore" data-score="0.66" />
   <text x="220.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
-  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(158, 208, 52)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="respect-user-attention" data-score="0.34" />
+  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(157, 208, 52)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="respect-user-attention" data-score="0.34" />
   <text x="328.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.34</text>
   <rect x="372" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(119, 201, 63)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="enable-meaningful-choices" data-score="0.61" />
   <text x="412.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.61</text>
-  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="enhance-human-capabilities" data-score="0.81" />
+  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="enhance-human-capabilities" data-score="0.81" />
   <text x="496.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <rect x="540" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.75" />
   <text x="580.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
-  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(112, 200, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="foster-healthy-relationships" data-score="0.66" />
+  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(113, 200, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="foster-healthy-relationships" data-score="0.66" />
   <text x="664.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
-  <rect x="708" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.82" />
+  <rect x="708" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.82" />
   <text x="748.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(122, 202, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.59" />
+  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(123, 202, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.59" />
   <text x="832.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.59</text>
-  <rect x="876" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(108, 199, 66)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.69" />
-  <text x="916.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.69</text>
+  <rect x="876" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 68)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.72" />
+  <text x="916.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.72</text>
   <text x="0" y="151.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4</text>
-  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(134, 204, 59)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="HumaneScore" data-score="0.51" />
-  <text x="220.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.51</text>
+  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(135, 204, 59)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="HumaneScore" data-score="0.50" />
+  <text x="220.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.50</text>
   <rect x="288" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(161, 209, 51)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="respect-user-attention" data-score="0.32" />
   <text x="328.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.32</text>
-  <rect x="372" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(149, 207, 54)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.40" />
+  <rect x="372" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(150, 207, 54)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.40" />
   <text x="412.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.40</text>
   <rect x="456" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="enhance-human-capabilities" data-score="0.75" />
   <text x="496.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
   <rect x="540" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(138, 205, 58)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="protect-dignity-and-safety" data-score="0.48" />
   <text x="580.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.48</text>
-  <rect x="624" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(166, 210, 49)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.28" />
+  <rect x="624" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(167, 210, 49)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.28" />
   <text x="664.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.28</text>
   <rect x="708" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(117, 201, 64)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.63" />
   <text x="748.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.63</text>
-  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(142, 205, 56)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.45" />
-  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.45</text>
-  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(102, 198, 68)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.73" />
-  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.73</text>
+  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(144, 206, 56)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.44" />
+  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.44</text>
+  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(103, 198, 68)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.72" />
+  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.72</text>
   <text x="0" y="185.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 4 Maverick</text>
   <rect x="180" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(209, 190, 46)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="HumaneScore" data-score="-0.14" />
   <text x="220.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.14</text>
-  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(223, 79, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="respect-user-attention" data-score="-0.72" />
+  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(222, 80, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="respect-user-attention" data-score="-0.72" />
   <text x="328.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.72</text>
   <rect x="372" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(207, 209, 40)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="enable-meaningful-choices" data-score="-0.04" />
   <text x="412.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.04</text>
   <rect x="456" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(151, 207, 54)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="enhance-human-capabilities" data-score="0.39" />
   <text x="496.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.39</text>
-  <rect x="540" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 42)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="protect-dignity-and-safety" data-score="-0.06" />
+  <rect x="540" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 41)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="protect-dignity-and-safety" data-score="-0.06" />
   <text x="580.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.06</text>
-  <rect x="624" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(211, 179, 50)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="foster-healthy-relationships" data-score="-0.20" />
+  <rect x="624" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(210, 180, 50)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="foster-healthy-relationships" data-score="-0.20" />
   <text x="664.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.20</text>
-  <rect x="708" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(192, 214, 42)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="prioritize-long-term-wellbeing" data-score="0.10" />
+  <rect x="708" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(192, 215, 42)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="prioritize-long-term-wellbeing" data-score="0.10" />
   <text x="748.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.10</text>
-  <rect x="792" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(222, 85, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="-0.69" />
+  <rect x="792" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(222, 85, 80)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="-0.69" />
   <text x="832.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.69</text>
-  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(197, 215, 40)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="design-for-equity-and-inclusion" data-score="0.06" />
-  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.06</text>
+  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(191, 214, 42)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-4-maverick" data-principle-id="design-for-equity-and-inclusion" data-score="0.11" />
+  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.11</text>
   <text x="0" y="219.0" class="font-weight-medium text-caption" dominant-baseline="middle">DeepSeek V3.1 Terminus</text>
-  <rect x="180" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(214, 150, 59)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="HumaneScore" data-score="-0.35" />
-  <text x="220.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.35</text>
-  <rect x="288" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(224, 66, 85)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="-0.79" />
+  <rect x="180" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(214, 149, 59)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="HumaneScore" data-score="-0.36" />
+  <text x="220.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.36</text>
+  <rect x="288" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(224, 65, 86)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="-0.79" />
   <text x="328.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.79</text>
-  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(213, 160, 56)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enable-meaningful-choices" data-score="-0.30" />
+  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(213, 159, 56)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enable-meaningful-choices" data-score="-0.30" />
   <text x="412.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.30</text>
   <rect x="456" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(188, 214, 43)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enhance-human-capabilities" data-score="0.13" />
   <text x="496.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.13</text>
@@ -133,20 +133,20 @@
   <text x="580.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.33</text>
   <rect x="624" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(218, 114, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="foster-healthy-relationships" data-score="-0.54" />
   <text x="664.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.54</text>
-  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(209, 188, 47)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.15" />
+  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(209, 189, 47)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.15" />
   <text x="748.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.15</text>
   <rect x="792" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(227, 45, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="be-transparent-and-honest" data-score="-0.90" />
   <text x="832.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.90</text>
-  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(199, 216, 40)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.05" />
-  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.05</text>
+  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(201, 216, 40)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.04" />
+  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.04</text>
   <text x="0" y="253.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 3 Pro Preview</text>
   <rect x="180" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(216, 131, 65)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="HumaneScore" data-score="-0.45" />
   <text x="220.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.45</text>
-  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(221, 91, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="respect-user-attention" data-score="-0.66" />
+  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(221, 92, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="respect-user-attention" data-score="-0.66" />
   <text x="328.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.66</text>
-  <rect x="372" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(220, 102, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="enable-meaningful-choices" data-score="-0.60" />
+  <rect x="372" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(220, 101, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="enable-meaningful-choices" data-score="-0.60" />
   <text x="412.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.60</text>
-  <rect x="456" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(219, 112, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="enhance-human-capabilities" data-score="-0.55" />
+  <rect x="456" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(219, 113, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="enhance-human-capabilities" data-score="-0.55" />
   <text x="496.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.55</text>
   <rect x="540" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(210, 185, 48)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="protect-dignity-and-safety" data-score="-0.17" />
   <text x="580.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.17</text>
@@ -154,92 +154,92 @@
   <text x="664.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.54</text>
   <rect x="708" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(217, 125, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.48" />
   <text x="748.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.48</text>
-  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(215, 141, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="-0.40" />
+  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(215, 140, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="-0.40" />
   <text x="832.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.40</text>
-  <rect x="876" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(210, 185, 48)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="-0.17" />
-  <text x="916.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.17</text>
+  <rect x="876" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(211, 177, 51)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="-0.21" />
+  <text x="916.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.21</text>
   <text x="0" y="287.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 3.1 405B Instruct</text>
-  <rect x="180" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(217, 123, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="HumaneScore" data-score="-0.49" />
+  <rect x="180" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(217, 124, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="HumaneScore" data-score="-0.49" />
   <text x="220.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.49</text>
-  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(226, 51, 90)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="-0.87" />
+  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(226, 50, 90)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="-0.87" />
   <text x="328.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.87</text>
-  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(214, 152, 58)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enable-meaningful-choices" data-score="-0.34" />
+  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(214, 153, 58)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enable-meaningful-choices" data-score="-0.34" />
   <text x="412.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.34</text>
   <rect x="456" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(209, 188, 47)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enhance-human-capabilities" data-score="-0.15" />
   <text x="496.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.15</text>
   <rect x="540" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(217, 127, 66)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="protect-dignity-and-safety" data-score="-0.47" />
   <text x="580.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.47</text>
-  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(219, 112, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="foster-healthy-relationships" data-score="-0.55" />
+  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(219, 111, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="foster-healthy-relationships" data-score="-0.55" />
   <text x="664.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.55</text>
-  <rect x="708" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(212, 164, 55)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.28" />
+  <rect x="708" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(213, 163, 55)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.28" />
   <text x="748.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.28</text>
-  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(226, 55, 89)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="be-transparent-and-honest" data-score="-0.85" />
-  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.85</text>
-  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(215, 139, 63)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="design-for-equity-and-inclusion" data-score="-0.41" />
-  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.41</text>
+  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(226, 52, 90)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="be-transparent-and-honest" data-score="-0.86" />
+  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.86</text>
+  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(214, 149, 59)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="llama-3.1-405b-instruct" data-principle-id="design-for-equity-and-inclusion" data-score="-0.36" />
+  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.36</text>
   <text x="0" y="321.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4.1</text>
-  <rect x="180" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(220, 102, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="HumaneScore" data-score="-0.60" />
-  <text x="220.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.60</text>
-  <rect x="288" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(228, 37, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="-0.94" />
+  <rect x="180" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(220, 101, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="HumaneScore" data-score="-0.61" />
+  <text x="220.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.61</text>
+  <rect x="288" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(228, 37, 95)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="-0.94" />
   <text x="328.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.94</text>
   <rect x="372" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(220, 100, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="enable-meaningful-choices" data-score="-0.61" />
   <text x="412.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.61</text>
-  <rect x="456" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(212, 165, 54)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="-0.27" />
+  <rect x="456" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(212, 166, 54)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="-0.27" />
   <text x="496.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.27</text>
-  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(220, 97, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="protect-dignity-and-safety" data-score="-0.63" />
+  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(221, 96, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="protect-dignity-and-safety" data-score="-0.63" />
   <text x="580.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.63</text>
   <rect x="624" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(223, 79, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="foster-healthy-relationships" data-score="-0.72" />
   <text x="664.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.72</text>
-  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(219, 110, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.56" />
+  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(219, 111, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.56" />
   <text x="748.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.56</text>
   <rect x="792" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(227, 45, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="be-transparent-and-honest" data-score="-0.90" />
   <text x="832.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.90</text>
-  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(210, 181, 49)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="-0.19" />
-  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.19</text>
+  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(211, 173, 52)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="-0.23" />
+  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.23</text>
   <text x="0" y="355.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4o (2024-11-20)</text>
-  <rect x="180" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(220, 100, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="HumaneScore" data-score="-0.61" />
+  <rect x="180" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(220, 101, 75)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="HumaneScore" data-score="-0.61" />
   <text x="220.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.61</text>
-  <rect x="288" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(226, 47, 91)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="-0.89" />
+  <rect x="288" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(227, 47, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="-0.89" />
   <text x="328.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.89</text>
-  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(220, 104, 73)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="-0.59" />
+  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(220, 104, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="-0.59" />
   <text x="412.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.59</text>
-  <rect x="456" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(211, 177, 51)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="-0.21" />
+  <rect x="456" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(211, 176, 51)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="-0.21" />
   <text x="496.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.21</text>
-  <rect x="540" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(220, 97, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="protect-dignity-and-safety" data-score="-0.63" />
+  <rect x="540" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(221, 96, 76)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="protect-dignity-and-safety" data-score="-0.63" />
   <text x="580.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.63</text>
-  <rect x="624" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(224, 70, 84)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="foster-healthy-relationships" data-score="-0.77" />
+  <rect x="624" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(224, 69, 84)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="foster-healthy-relationships" data-score="-0.77" />
   <text x="664.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.77</text>
-  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(218, 120, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.51" />
+  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(218, 119, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.51" />
   <text x="748.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.51</text>
-  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(226, 53, 90)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="-0.86" />
+  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(226, 52, 90)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="-0.86" />
   <text x="832.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.86</text>
-  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(215, 139, 63)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="-0.41" />
-  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.41</text>
+  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(215, 142, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="-0.39" />
+  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.39</text>
   <text x="0" y="389.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Flash</text>
   <rect x="180" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(222, 87, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="HumaneScore" data-score="-0.68" />
   <text x="220.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.68</text>
-  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(227, 45, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="-0.90" />
+  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(227, 46, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="-0.90" />
   <text x="328.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.90</text>
-  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(222, 87, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="enable-meaningful-choices" data-score="-0.68" />
+  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(222, 88, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="enable-meaningful-choices" data-score="-0.68" />
   <text x="412.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.68</text>
-  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(215, 139, 63)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="enhance-human-capabilities" data-score="-0.41" />
+  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(215, 140, 62)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="enhance-human-capabilities" data-score="-0.41" />
   <text x="496.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.41</text>
-  <rect x="540" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(221, 91, 78)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="protect-dignity-and-safety" data-score="-0.66" />
+  <rect x="540" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(221, 92, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="protect-dignity-and-safety" data-score="-0.66" />
   <text x="580.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.66</text>
   <rect x="624" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(225, 58, 88)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="foster-healthy-relationships" data-score="-0.83" />
   <text x="664.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.83</text>
-  <rect x="708" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(219, 110, 72)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.56" />
+  <rect x="708" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(219, 111, 71)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.56" />
   <text x="748.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.56</text>
   <rect x="792" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(227, 45, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="be-transparent-and-honest" data-score="-0.90" />
   <text x="832.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.90</text>
-  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(218, 116, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="design-for-equity-and-inclusion" data-score="-0.53" />
+  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(218, 117, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-flash" data-principle-id="design-for-equity-and-inclusion" data-score="-0.53" />
   <text x="916.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.53</text>
   <text x="0" y="423.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.0 Flash 001</text>
-  <rect x="180" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(222, 81, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="HumaneScore" data-score="-0.71" />
+  <rect x="180" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(222, 82, 80)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="HumaneScore" data-score="-0.71" />
   <text x="220.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.71</text>
-  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(228, 37, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="respect-user-attention" data-score="-0.94" />
+  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(228, 38, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="respect-user-attention" data-score="-0.94" />
   <text x="328.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.94</text>
-  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(223, 78, 82)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="-0.73" />
+  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(223, 77, 82)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="-0.73" />
   <text x="412.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.73</text>
   <rect x="456" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(217, 125, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="enhance-human-capabilities" data-score="-0.48" />
   <text x="496.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.48</text>
@@ -247,30 +247,30 @@
   <text x="580.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.68</text>
   <rect x="624" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(226, 55, 89)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="foster-healthy-relationships" data-score="-0.85" />
   <text x="664.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.85</text>
-  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(220, 104, 73)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.59" />
+  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(220, 103, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.59" />
   <text x="748.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.59</text>
   <rect x="792" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(226, 55, 89)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="be-transparent-and-honest" data-score="-0.85" />
   <text x="832.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.85</text>
-  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(218, 116, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="-0.53" />
-  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.53</text>
+  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(218, 117, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="-0.52" />
+  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.52</text>
   <text x="0" y="457.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Pro</text>
   <rect x="180" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(223, 79, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="HumaneScore" data-score="-0.72" />
   <text x="220.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.72</text>
-  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(227, 39, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="-0.93" />
+  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(227, 40, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="-0.93" />
   <text x="328.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.93</text>
-  <rect x="372" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(224, 68, 85)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="enable-meaningful-choices" data-score="-0.78" />
+  <rect x="372" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(224, 67, 85)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="enable-meaningful-choices" data-score="-0.78" />
   <text x="412.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.78</text>
   <rect x="456" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(214, 152, 58)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="enhance-human-capabilities" data-score="-0.34" />
   <text x="496.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.34</text>
   <rect x="540" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(223, 78, 82)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="protect-dignity-and-safety" data-score="-0.73" />
   <text x="580.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.73</text>
-  <rect x="624" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(227, 43, 93)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="-0.91" />
+  <rect x="624" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(227, 44, 92)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="-0.91" />
   <text x="664.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.91</text>
-  <rect x="708" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(221, 93, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.65" />
+  <rect x="708" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(221, 94, 77)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.65" />
   <text x="748.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.65</text>
-  <rect x="792" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(228, 36, 95)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="-0.95" />
+  <rect x="792" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(228, 35, 95)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="-0.95" />
   <text x="832.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.95</text>
-  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(217, 123, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="design-for-equity-and-inclusion" data-score="-0.49" />
+  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(217, 123, 68)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="gemini-2.5-pro" data-principle-id="design-for-equity-and-inclusion" data-score="-0.49" />
   <text x="916.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.49</text>
   <text x="0" y="491.0" class="font-weight-medium text-caption" dominant-baseline="middle">Grok 4</text>
   <rect x="180" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(223, 78, 82)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="HumaneScore" data-score="-0.73" />
@@ -279,18 +279,18 @@
   <text x="328.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.94</text>
   <rect x="372" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(223, 79, 81)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="enable-meaningful-choices" data-score="-0.72" />
   <text x="412.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.72</text>
-  <rect x="456" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(217, 123, 67)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="enhance-human-capabilities" data-score="-0.49" />
+  <rect x="456" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(217, 122, 68)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="enhance-human-capabilities" data-score="-0.49" />
   <text x="496.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.49</text>
-  <rect x="540" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(222, 87, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="-0.68" />
+  <rect x="540" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(222, 86, 79)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="-0.68" />
   <text x="580.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.68</text>
   <rect x="624" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(227, 43, 93)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="foster-healthy-relationships" data-score="-0.91" />
   <text x="664.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.91</text>
   <rect x="708" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(220, 102, 74)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="prioritize-long-term-wellbeing" data-score="-0.60" />
   <text x="748.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.60</text>
-  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(228, 37, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="-0.94" />
+  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(228, 38, 94)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="-0.94" />
   <text x="832.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.94</text>
-  <rect x="876" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(218, 116, 70)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="-0.53" />
-  <text x="916.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.53</text>
+  <rect x="876" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(218, 117, 69)" class="score-cell cursor-pointer" data-dataset="bad_persona" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="-0.52" />
+  <text x="916.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.52</text>
   <text x="220.0" y="520" text-anchor="end" dominant-baseline="middle" transform="rotate(-45, 220.0, 520)" class="text-caption font-weight-medium font-weight-bold">HumaneScore</text>
   <text x="328.0" y="520" text-anchor="end" dominant-baseline="middle" transform="rotate(-45, 328.0, 520)" class="text-caption font-weight-medium">Respect User Attention</text>
   <text x="412.0" y="520" text-anchor="end" dominant-baseline="middle" transform="rotate(-45, 412.0, 520)" class="text-caption font-weight-medium">Enable Meaningful Choices</text>

--- a/figures/scoregrid_baseline.svg
+++ b/figures/scoregrid_baseline.svg
@@ -6,43 +6,43 @@
     .font-weight-bold { font-weight: 700; }
   </style>
   <desc>Generated from eval_results/baseline</desc>
-  <text x="0" y="15.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5</text>
-  <rect x="180" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="HumaneScore" data-score="0.86" />
+  <text x="0" y="15.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5.1</text>
+  <rect x="180" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(83, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.86" />
   <text x="220.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="288" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(156, 208, 52)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="respect-user-attention" data-score="0.35" />
-  <text x="328.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.35</text>
-  <rect x="372" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="enable-meaningful-choices" data-score="0.94" />
-  <text x="412.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.96" />
-  <text x="496.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
-  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
+  <rect x="288" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(166, 210, 49)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="respect-user-attention" data-score="0.28" />
+  <text x="328.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.28</text>
+  <rect x="372" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="enable-meaningful-choices" data-score="0.96" />
+  <text x="412.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
+  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="enhance-human-capabilities" data-score="0.97" />
+  <text x="496.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
+  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
   <text x="580.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="624" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="foster-healthy-relationships" data-score="0.94" />
+  <rect x="624" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="foster-healthy-relationships" data-score="0.94" />
   <text x="664.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="708" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
+  <rect x="708" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.79" />
-  <text x="832.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
-  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.94" />
-  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <text x="0" y="49.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5.1</text>
-  <rect x="180" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.86" />
+  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="be-transparent-and-honest" data-score="0.85" />
+  <text x="832.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
+  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.95" />
+  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
+  <text x="0" y="49.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5</text>
+  <rect x="180" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="HumaneScore" data-score="0.86" />
   <text x="220.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="288" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(166, 210, 49)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="respect-user-attention" data-score="0.28" />
-  <text x="328.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.28</text>
-  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="enable-meaningful-choices" data-score="0.96" />
-  <text x="412.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
-  <rect x="456" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="enhance-human-capabilities" data-score="0.97" />
-  <text x="496.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="540" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
+  <rect x="288" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(156, 208, 53)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="respect-user-attention" data-score="0.35" />
+  <text x="328.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.35</text>
+  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="enable-meaningful-choices" data-score="0.94" />
+  <text x="412.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
+  <rect x="456" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.96" />
+  <text x="496.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
+  <rect x="540" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
   <text x="580.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="624" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="foster-healthy-relationships" data-score="0.94" />
+  <rect x="624" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="foster-healthy-relationships" data-score="0.94" />
   <text x="664.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="708" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
+  <rect x="708" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="be-transparent-and-honest" data-score="0.85" />
-  <text x="832.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
-  <rect x="876" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.94" />
+  <rect x="792" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.79" />
+  <text x="832.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
+  <rect x="876" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(72, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.94" />
   <text x="916.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
   <text x="0" y="83.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 3 Pro Preview</text>
   <rect x="180" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="HumaneScore" data-score="0.78" />
@@ -59,31 +59,31 @@
   <text x="664.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
   <rect x="708" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="prioritize-long-term-wellbeing" data-score="0.97" />
   <text x="748.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="792" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="0.68" />
+  <rect x="792" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(110, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="0.68" />
   <text x="832.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
-  <rect x="876" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="0.84" />
+  <rect x="876" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="0.84" />
   <text x="916.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
   <text x="0" y="117.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Pro</text>
-  <rect x="180" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="HumaneScore" data-score="0.77" />
-  <text x="220.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
-  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(206, 215, 39)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="-0.01" />
+  <rect x="180" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="HumaneScore" data-score="0.76" />
+  <text x="220.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.76</text>
+  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(206, 216, 38)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="-0.01" />
   <text x="328.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.01</text>
-  <rect x="372" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="enable-meaningful-choices" data-score="0.82" />
+  <rect x="372" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="enable-meaningful-choices" data-score="0.82" />
   <text x="412.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="enhance-human-capabilities" data-score="0.96" />
+  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="enhance-human-capabilities" data-score="0.96" />
   <text x="496.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
   <rect x="540" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="protect-dignity-and-safety" data-score="0.92" />
   <text x="580.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="0.92" />
+  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="0.92" />
   <text x="664.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="708" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
+  <rect x="708" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
   <text x="748.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
-  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(112, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="0.66" />
-  <text x="832.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
-  <rect x="876" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="design-for-equity-and-inclusion" data-score="0.87" />
-  <text x="916.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
+  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(113, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="0.65" />
+  <text x="832.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
+  <rect x="876" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-pro" data-principle-id="design-for-equity-and-inclusion" data-score="0.86" />
+  <text x="916.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
   <text x="0" y="151.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4.5</text>
-  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.75" />
+  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(99, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.75" />
   <text x="220.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
   <rect x="288" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(169, 210, 49)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="respect-user-attention" data-score="0.26" />
   <text x="328.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.26</text>
@@ -91,24 +91,24 @@
   <text x="412.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
   <rect x="456" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="enhance-human-capabilities" data-score="0.92" />
   <text x="496.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="540" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="protect-dignity-and-safety" data-score="0.79" />
+  <rect x="540" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="protect-dignity-and-safety" data-score="0.79" />
   <text x="580.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
   <rect x="624" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="foster-healthy-relationships" data-score="0.88" />
   <text x="664.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
   <rect x="708" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
   <text x="748.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="be-transparent-and-honest" data-score="0.65" />
-  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
-  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.81" />
-  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
+  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(115, 200, 64)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="be-transparent-and-honest" data-score="0.64" />
+  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.64</text>
+  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.83" />
+  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <text x="0" y="185.0" class="font-weight-medium text-caption" dominant-baseline="middle">DeepSeek V3.1 Terminus</text>
-  <rect x="180" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="HumaneScore" data-score="0.75" />
+  <rect x="180" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(99, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="HumaneScore" data-score="0.75" />
   <text x="220.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
-  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(207, 211, 40)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="-0.03" />
+  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(207, 212, 40)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="-0.03" />
   <text x="328.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.03</text>
   <rect x="372" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="enable-meaningful-choices" data-score="0.82" />
   <text x="412.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="456" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="enhance-human-capabilities" data-score="0.98" />
+  <rect x="456" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="enhance-human-capabilities" data-score="0.98" />
   <text x="496.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
   <rect x="540" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="protect-dignity-and-safety" data-score="0.91" />
   <text x="580.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
@@ -118,14 +118,14 @@
   <text x="748.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
   <rect x="792" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(122, 202, 62)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="be-transparent-and-honest" data-score="0.59" />
   <text x="832.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.59</text>
-  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.86" />
-  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
+  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.85" />
+  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
   <text x="0" y="219.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.0 Flash 001</text>
   <rect x="180" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="HumaneScore" data-score="0.75" />
   <text x="220.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
   <rect x="288" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(207, 209, 40)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="respect-user-attention" data-score="-0.04" />
   <text x="328.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.04</text>
-  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="0.88" />
+  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="0.88" />
   <text x="412.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
   <rect x="456" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="enhance-human-capabilities" data-score="0.97" />
   <text x="496.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
@@ -133,16 +133,16 @@
   <text x="580.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
   <rect x="624" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="foster-healthy-relationships" data-score="0.91" />
   <text x="664.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
+  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 79)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(122, 202, 62)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="be-transparent-and-honest" data-score="0.59" />
+  <rect x="792" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(123, 202, 62)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="be-transparent-and-honest" data-score="0.59" />
   <text x="832.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.59</text>
-  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(98, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="0.76" />
-  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.76</text>
+  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="0.79" />
+  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
   <text x="0" y="253.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Flash</text>
   <rect x="180" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 68)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="HumaneScore" data-score="0.72" />
   <text x="220.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.72</text>
-  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(209, 196, 45)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="-0.11" />
+  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(208, 196, 44)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="-0.11" />
   <text x="328.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.11</text>
   <rect x="372" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="enable-meaningful-choices" data-score="0.84" />
   <text x="412.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
@@ -150,33 +150,33 @@
   <text x="496.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
   <rect x="540" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="protect-dignity-and-safety" data-score="0.91" />
   <text x="580.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="624" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="foster-healthy-relationships" data-score="0.92" />
+  <rect x="624" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="foster-healthy-relationships" data-score="0.92" />
   <text x="664.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="708" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="0.96" />
+  <rect x="708" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="0.96" />
   <text x="748.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
-  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(135, 204, 58)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="be-transparent-and-honest" data-score="0.50" />
-  <text x="832.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.50</text>
+  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(136, 204, 58)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="be-transparent-and-honest" data-score="0.49" />
+  <text x="832.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.49</text>
   <rect x="876" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gemini-2.5-flash" data-principle-id="design-for-equity-and-inclusion" data-score="0.78" />
   <text x="916.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
   <text x="0" y="287.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4</text>
   <rect x="180" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(108, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="HumaneScore" data-score="0.69" />
   <text x="220.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.69</text>
-  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 42)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="respect-user-attention" data-score="-0.06" />
+  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 41)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="respect-user-attention" data-score="-0.06" />
   <text x="328.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.06</text>
-  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.77" />
+  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(96, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.77" />
   <text x="412.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
   <rect x="456" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="enhance-human-capabilities" data-score="0.92" />
   <text x="496.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
   <rect x="540" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="protect-dignity-and-safety" data-score="0.80" />
   <text x="580.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
-  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.92" />
+  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.92" />
   <text x="664.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
   <rect x="708" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
   <text x="748.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(149, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.40" />
-  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.40</text>
-  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.81" />
-  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
+  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(150, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.39" />
+  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.39</text>
+  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.83" />
+  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <text x="0" y="321.0" class="font-weight-medium text-caption" dominant-baseline="middle">Grok 4</text>
   <rect x="180" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(108, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="HumaneScore" data-score="0.69" />
   <text x="220.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.69</text>
@@ -186,22 +186,22 @@
   <text x="412.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <rect x="456" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="enhance-human-capabilities" data-score="0.93" />
   <text x="496.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
-  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
+  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
   <text x="580.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
   <rect x="624" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="foster-healthy-relationships" data-score="0.89" />
   <text x="664.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
+  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
   <text x="748.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="792" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(129, 203, 60)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="0.54" />
+  <rect x="792" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(130, 203, 60)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="0.54" />
   <text x="832.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.54</text>
-  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.79" />
-  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
+  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.80" />
+  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
   <text x="0" y="355.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Opus 4.1</text>
   <rect x="180" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="HumaneScore" data-score="0.68" />
   <text x="220.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
   <rect x="288" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(207, 209, 40)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="respect-user-attention" data-score="-0.04" />
   <text x="328.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.04</text>
-  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="enable-meaningful-choices" data-score="0.75" />
+  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(99, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="enable-meaningful-choices" data-score="0.75" />
   <text x="412.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
   <rect x="456" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="enhance-human-capabilities" data-score="0.94" />
   <text x="496.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
@@ -209,20 +209,20 @@
   <text x="580.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <rect x="624" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="foster-healthy-relationships" data-score="0.85" />
   <text x="664.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
-  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
+  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
   <text x="748.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(151, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.39" />
-  <text x="832.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.39</text>
-  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.83" />
-  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
+  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(152, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.38" />
+  <text x="832.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.38</text>
+  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.84" />
+  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
   <text x="0" y="389.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4o (2024-11-20)</text>
   <rect x="180" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="HumaneScore" data-score="0.68" />
   <text x="220.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
-  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(202, 216, 39)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="0.03" />
+  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(201, 216, 39)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="0.03" />
   <text x="328.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.03</text>
-  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(102, 198, 68)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="0.73" />
+  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(103, 198, 68)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="0.73" />
   <text x="412.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.73</text>
-  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="0.81" />
+  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="0.81" />
   <text x="496.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <rect x="540" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="protect-dignity-and-safety" data-score="0.81" />
   <text x="580.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
@@ -230,52 +230,52 @@
   <text x="664.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
   <rect x="708" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
   <text x="748.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="792" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(134, 204, 59)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="0.51" />
-  <text x="832.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.51</text>
-  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="0.75" />
-  <text x="916.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.75</text>
+  <rect x="792" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(135, 204, 58)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="0.50" />
+  <text x="832.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.50</text>
+  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="0.79" />
+  <text x="916.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
   <text x="0" y="423.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4.1</text>
   <rect x="180" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(111, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="HumaneScore" data-score="0.67" />
   <text x="220.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.67</text>
-  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(211, 179, 50)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="-0.20" />
+  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(211, 178, 50)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="-0.20" />
   <text x="328.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.20</text>
-  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="enable-meaningful-choices" data-score="0.77" />
+  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 69)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="enable-meaningful-choices" data-score="0.77" />
   <text x="412.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
-  <rect x="456" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="0.82" />
+  <rect x="456" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="0.82" />
   <text x="496.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
   <rect x="540" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.86" />
   <text x="580.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
   <rect x="624" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="foster-healthy-relationships" data-score="0.86" />
   <text x="664.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
+  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
   <text x="748.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="792" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(136, 204, 58)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="be-transparent-and-honest" data-score="0.49" />
+  <rect x="792" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(137, 204, 58)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="be-transparent-and-honest" data-score="0.49" />
   <text x="832.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.49</text>
-  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.80" />
-  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
+  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.81" />
+  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <text x="0" y="457.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 4 Maverick</text>
   <rect x="180" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(122, 202, 62)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="HumaneScore" data-score="0.59" />
   <text x="220.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.59</text>
-  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(209, 196, 45)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="respect-user-attention" data-score="-0.11" />
+  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(208, 197, 44)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="respect-user-attention" data-score="-0.11" />
   <text x="328.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.11</text>
   <rect x="372" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(121, 201, 63)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="enable-meaningful-choices" data-score="0.60" />
   <text x="412.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.60</text>
-  <rect x="456" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="enhance-human-capabilities" data-score="0.82" />
+  <rect x="456" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="enhance-human-capabilities" data-score="0.82" />
   <text x="496.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="540" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="protect-dignity-and-safety" data-score="0.68" />
+  <rect x="540" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(110, 199, 66)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="protect-dignity-and-safety" data-score="0.68" />
   <text x="580.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
   <rect x="624" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="foster-healthy-relationships" data-score="0.85" />
   <text x="664.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
   <rect x="708" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="prioritize-long-term-wellbeing" data-score="0.85" />
   <text x="748.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
-  <rect x="792" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(152, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="0.38" />
+  <rect x="792" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(151, 207, 54)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="0.38" />
   <text x="832.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.38</text>
-  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="design-for-equity-and-inclusion" data-score="0.65" />
-  <text x="916.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
+  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(113, 200, 65)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-4-maverick" data-principle-id="design-for-equity-and-inclusion" data-score="0.66" />
+  <text x="916.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
   <text x="0" y="491.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 3.1 405B Instruct</text>
-  <rect x="180" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(126, 202, 61)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="HumaneScore" data-score="0.56" />
+  <rect x="180" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(127, 203, 61)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="HumaneScore" data-score="0.56" />
   <text x="220.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.56</text>
-  <rect x="288" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 42)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="-0.06" />
+  <rect x="288" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(207, 206, 41)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="-0.06" />
   <text x="328.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">-0.06</text>
   <rect x="372" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(134, 204, 59)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="enable-meaningful-choices" data-score="0.51" />
   <text x="412.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.51</text>
@@ -287,8 +287,8 @@
   <text x="664.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
   <rect x="708" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="prioritize-long-term-wellbeing" data-score="0.80" />
   <text x="748.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
-  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(165, 209, 50)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="be-transparent-and-honest" data-score="0.29" />
-  <text x="832.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.29</text>
+  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(166, 210, 50)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="be-transparent-and-honest" data-score="0.28" />
+  <text x="832.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.28</text>
   <rect x="876" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(107, 199, 67)" class="score-cell cursor-pointer" data-dataset="baseline" data-model="llama-3.1-405b-instruct" data-principle-id="design-for-equity-and-inclusion" data-score="0.70" />
   <text x="916.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.70</text>
   <text x="220.0" y="520" text-anchor="end" dominant-baseline="middle" transform="rotate(-45, 220.0, 520)" class="text-caption font-weight-medium font-weight-bold">HumaneScore</text>

--- a/figures/scoregrid_good_persona.svg
+++ b/figures/scoregrid_good_persona.svg
@@ -9,28 +9,28 @@
   <text x="0" y="15.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5</text>
   <rect x="180" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="HumaneScore" data-score="0.94" />
   <text x="220.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="288" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="respect-user-attention" data-score="0.82" />
+  <rect x="288" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="respect-user-attention" data-score="0.82" />
   <text x="328.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="372" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="enable-meaningful-choices" data-score="0.96" />
+  <rect x="372" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="enable-meaningful-choices" data-score="0.96" />
   <text x="412.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
-  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.98" />
+  <rect x="456" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(67, 191, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="enhance-human-capabilities" data-score="0.98" />
   <text x="496.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
-  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
+  <rect x="540" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="protect-dignity-and-safety" data-score="0.97" />
   <text x="580.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="624" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="foster-healthy-relationships" data-score="0.94" />
+  <rect x="624" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="foster-healthy-relationships" data-score="0.94" />
   <text x="664.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
   <rect x="708" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.91" />
-  <text x="832.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.96" />
-  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
+  <rect x="792" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="be-transparent-and-honest" data-score="0.90" />
+  <text x="832.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
+  <rect x="876" y="0" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5" data-principle-id="design-for-equity-and-inclusion" data-score="0.95" />
+  <text x="916.0" y="15.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
   <text x="0" y="49.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 3 Pro Preview</text>
   <rect x="180" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="HumaneScore" data-score="0.93" />
   <text x="220.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
-  <rect x="288" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="respect-user-attention" data-score="0.79" />
+  <rect x="288" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(94, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="respect-user-attention" data-score="0.79" />
   <text x="328.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
-  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="enable-meaningful-choices" data-score="0.96" />
+  <rect x="372" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="enable-meaningful-choices" data-score="0.96" />
   <text x="412.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
   <rect x="456" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="enhance-human-capabilities" data-score="0.99" />
   <text x="496.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
@@ -40,229 +40,229 @@
   <text x="664.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
   <rect x="708" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="0.91" />
-  <text x="832.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="876" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
+  <rect x="792" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="be-transparent-and-honest" data-score="0.92" />
+  <text x="832.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="876" y="34" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-3-pro-preview" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
   <text x="916.0" y="49.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
   <text x="0" y="83.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-5.1</text>
-  <rect x="180" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.92" />
+  <rect x="180" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="HumaneScore" data-score="0.92" />
   <text x="220.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="288" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(112, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="respect-user-attention" data-score="0.66" />
+  <rect x="288" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(113, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="respect-user-attention" data-score="0.66" />
   <text x="328.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.66</text>
   <rect x="372" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="enable-meaningful-choices" data-score="0.97" />
   <text x="412.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
   <rect x="456" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="enhance-human-capabilities" data-score="0.97" />
   <text x="496.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="540" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="protect-dignity-and-safety" data-score="0.96" />
+  <rect x="540" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="protect-dignity-and-safety" data-score="0.96" />
   <text x="580.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
   <rect x="624" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="foster-healthy-relationships" data-score="0.93" />
   <text x="664.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
   <rect x="708" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(64, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="prioritize-long-term-wellbeing" data-score="1.00" />
   <text x="748.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">1.00</text>
-  <rect x="792" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="be-transparent-and-honest" data-score="0.89" />
-  <text x="832.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <rect x="792" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="be-transparent-and-honest" data-score="0.88" />
+  <text x="832.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
   <rect x="876" y="68" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-5.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.96" />
   <text x="916.0" y="83.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
   <text x="0" y="117.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Pro</text>
   <rect x="180" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="HumaneScore" data-score="0.90" />
   <text x="220.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="0.77" />
+  <rect x="288" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(96, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="respect-user-attention" data-score="0.77" />
   <text x="328.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
   <rect x="372" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="enable-meaningful-choices" data-score="0.92" />
   <text x="412.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="enhance-human-capabilities" data-score="0.99" />
+  <rect x="456" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="enhance-human-capabilities" data-score="0.99" />
   <text x="496.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="540" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="protect-dignity-and-safety" data-score="0.90" />
+  <rect x="540" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="protect-dignity-and-safety" data-score="0.90" />
   <text x="580.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="0.95" />
+  <rect x="624" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="foster-healthy-relationships" data-score="0.95" />
   <text x="664.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
   <rect x="708" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(65, 191, 79)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="prioritize-long-term-wellbeing" data-score="0.99" />
   <text x="748.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.99</text>
-  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(91, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="0.81" />
+  <rect x="792" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="be-transparent-and-honest" data-score="0.81" />
   <text x="832.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <rect x="876" y="102" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-pro" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
   <text x="916.0" y="117.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <text x="0" y="151.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4.5</text>
-  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.89" />
+  <text x="0" y="151.0" class="font-weight-medium text-caption" dominant-baseline="middle">Grok 4</text>
+  <rect x="180" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="HumaneScore" data-score="0.89" />
   <text x="220.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="288" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(105, 199, 67)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="respect-user-attention" data-score="0.71" />
-  <text x="328.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.71</text>
-  <rect x="372" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="enable-meaningful-choices" data-score="0.93" />
-  <text x="412.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
-  <rect x="456" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="enhance-human-capabilities" data-score="0.98" />
-  <text x="496.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
-  <rect x="540" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="protect-dignity-and-safety" data-score="0.89" />
-  <text x="580.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="624" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="foster-healthy-relationships" data-score="0.90" />
-  <text x="664.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <rect x="708" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
-  <text x="748.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="be-transparent-and-honest" data-score="0.89" />
-  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.87" />
-  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
-  <text x="0" y="185.0" class="font-weight-medium text-caption" dominant-baseline="middle">Grok 4</text>
-  <rect x="180" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="HumaneScore" data-score="0.89" />
+  <rect x="288" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(110, 199, 66)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="respect-user-attention" data-score="0.68" />
+  <text x="328.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
+  <rect x="372" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="enable-meaningful-choices" data-score="0.95" />
+  <text x="412.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
+  <rect x="456" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(69, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="enhance-human-capabilities" data-score="0.96" />
+  <text x="496.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
+  <rect x="540" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
+  <text x="580.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
+  <rect x="624" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(66, 191, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="foster-healthy-relationships" data-score="0.98" />
+  <text x="664.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
+  <rect x="708" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
+  <text x="748.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
+  <rect x="792" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(98, 197, 69)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="0.76" />
+  <text x="832.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.76</text>
+  <rect x="876" y="136" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
+  <text x="916.0" y="151.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
+  <text x="0" y="185.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4.5</text>
+  <rect x="180" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="HumaneScore" data-score="0.89" />
   <text x="220.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="respect-user-attention" data-score="0.68" />
-  <text x="328.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
-  <rect x="372" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="enable-meaningful-choices" data-score="0.95" />
-  <text x="412.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="456" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(70, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="enhance-human-capabilities" data-score="0.96" />
-  <text x="496.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.96</text>
-  <rect x="540" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="protect-dignity-and-safety" data-score="0.94" />
-  <text x="580.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="624" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="foster-healthy-relationships" data-score="0.98" />
-  <text x="664.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
-  <rect x="708" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.98" />
-  <text x="748.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
-  <rect x="792" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="be-transparent-and-honest" data-score="0.77" />
-  <text x="832.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
-  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="grok-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.89" />
-  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <text x="0" y="219.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Opus 4.1</text>
-  <rect x="180" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="HumaneScore" data-score="0.84" />
+  <rect x="288" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 67)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="respect-user-attention" data-score="0.71" />
+  <text x="328.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.71</text>
+  <rect x="372" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(74, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="enable-meaningful-choices" data-score="0.93" />
+  <text x="412.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.93</text>
+  <rect x="456" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="enhance-human-capabilities" data-score="0.98" />
+  <text x="496.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
+  <rect x="540" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="protect-dignity-and-safety" data-score="0.89" />
+  <text x="580.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <rect x="624" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="foster-healthy-relationships" data-score="0.90" />
+  <text x="664.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
+  <rect x="708" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
+  <text x="748.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
+  <rect x="792" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="be-transparent-and-honest" data-score="0.88" />
+  <text x="832.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
+  <rect x="876" y="170" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4.5" data-principle-id="design-for-equity-and-inclusion" data-score="0.88" />
+  <text x="916.0" y="185.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
+  <text x="0" y="219.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4</text>
+  <rect x="180" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="HumaneScore" data-score="0.84" />
   <text x="220.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
-  <rect x="288" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(132, 203, 59)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="respect-user-attention" data-score="0.52" />
-  <text x="328.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.52</text>
-  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="enable-meaningful-choices" data-score="0.85" />
-  <text x="412.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
-  <rect x="456" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="enhance-human-capabilities" data-score="0.97" />
+  <rect x="288" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(121, 201, 62)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="respect-user-attention" data-score="0.60" />
+  <text x="328.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.60</text>
+  <rect x="372" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.86" />
+  <text x="412.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
+  <rect x="456" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="enhance-human-capabilities" data-score="0.97" />
   <text x="496.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="540" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.86" />
-  <text x="580.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="624" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="foster-healthy-relationships" data-score="0.88" />
+  <rect x="540" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="protect-dignity-and-safety" data-score="0.83" />
+  <text x="580.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
+  <rect x="624" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.88" />
   <text x="664.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
-  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.97" />
-  <text x="748.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="792" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.79" />
-  <text x="832.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
-  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
-  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <text x="0" y="253.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Sonnet 4</text>
-  <rect x="180" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="HumaneScore" data-score="0.84" />
+  <rect x="708" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
+  <text x="748.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
+  <rect x="792" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(96, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.78" />
+  <text x="832.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
+  <rect x="876" y="204" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.89" />
+  <text x="916.0" y="219.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <text x="0" y="253.0" class="font-weight-medium text-caption" dominant-baseline="middle">Claude Opus 4.1</text>
+  <rect x="180" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="HumaneScore" data-score="0.84" />
   <text x="220.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
-  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(121, 201, 63)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="respect-user-attention" data-score="0.60" />
-  <text x="328.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.60</text>
-  <rect x="372" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="enable-meaningful-choices" data-score="0.86" />
-  <text x="412.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="456" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="enhance-human-capabilities" data-score="0.97" />
+  <rect x="288" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(133, 204, 59)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="respect-user-attention" data-score="0.52" />
+  <text x="328.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.52</text>
+  <rect x="372" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(85, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="enable-meaningful-choices" data-score="0.85" />
+  <text x="412.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
+  <rect x="456" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="enhance-human-capabilities" data-score="0.97" />
   <text x="496.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
-  <rect x="540" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="protect-dignity-and-safety" data-score="0.83" />
-  <text x="580.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
-  <rect x="624" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="foster-healthy-relationships" data-score="0.88" />
+  <rect x="540" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.86" />
+  <text x="580.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
+  <rect x="624" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="foster-healthy-relationships" data-score="0.88" />
   <text x="664.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
-  <rect x="708" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(73, 193, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="prioritize-long-term-wellbeing" data-score="0.94" />
-  <text x="748.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.94</text>
-  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="be-transparent-and-honest" data-score="0.78" />
-  <text x="832.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
-  <rect x="876" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-sonnet-4" data-principle-id="design-for-equity-and-inclusion" data-score="0.89" />
-  <text x="916.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <rect x="708" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(68, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.97" />
+  <text x="748.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.97</text>
+  <rect x="792" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="be-transparent-and-honest" data-score="0.79" />
+  <text x="832.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
+  <rect x="876" y="238" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="claude-opus-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.90" />
+  <text x="916.0" y="253.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
   <text x="0" y="287.0" class="font-weight-medium text-caption" dominant-baseline="middle">DeepSeek V3.1 Terminus</text>
   <rect x="180" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="HumaneScore" data-score="0.84" />
   <text x="220.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
-  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(126, 202, 61)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="0.56" />
+  <rect x="288" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(127, 202, 61)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="respect-user-attention" data-score="0.56" />
   <text x="328.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.56</text>
-  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enable-meaningful-choices" data-score="0.88" />
+  <rect x="372" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enable-meaningful-choices" data-score="0.88" />
   <text x="412.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
   <rect x="456" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(67, 192, 78)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="enhance-human-capabilities" data-score="0.98" />
   <text x="496.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.98</text>
   <rect x="540" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="protect-dignity-and-safety" data-score="0.88" />
   <text x="580.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
-  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="foster-healthy-relationships" data-score="0.90" />
+  <rect x="624" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="foster-healthy-relationships" data-score="0.90" />
   <text x="664.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
   <rect x="708" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
   <text x="748.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(108, 199, 66)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="be-transparent-and-honest" data-score="0.69" />
-  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.69</text>
-  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.87" />
-  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
-  <text x="0" y="321.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.0 Flash 001</text>
-  <rect x="180" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="HumaneScore" data-score="0.82" />
+  <rect x="792" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(107, 199, 67)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="be-transparent-and-honest" data-score="0.70" />
+  <text x="832.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.70</text>
+  <rect x="876" y="272" width="80" height="30" rx="8" ry="8" fill="rgb(79, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="deepseek-v3.1-terminus" data-principle-id="design-for-equity-and-inclusion" data-score="0.89" />
+  <text x="916.0" y="287.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <text x="0" y="321.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4.1</text>
+  <rect x="180" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="HumaneScore" data-score="0.82" />
   <text x="220.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="288" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(119, 201, 63)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="respect-user-attention" data-score="0.61" />
-  <text x="328.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.61</text>
-  <rect x="372" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="0.86" />
-  <text x="412.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="456" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="enhance-human-capabilities" data-score="0.92" />
-  <text x="496.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="protect-dignity-and-safety" data-score="0.87" />
-  <text x="580.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
-  <rect x="624" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="foster-healthy-relationships" data-score="0.91" />
-  <text x="664.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
-  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(71, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
-  <text x="748.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
-  <rect x="792" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(117, 201, 64)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="be-transparent-and-honest" data-score="0.63" />
-  <text x="832.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.63</text>
-  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="0.78" />
-  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
-  <text x="0" y="355.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4.1</text>
-  <rect x="180" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="HumaneScore" data-score="0.82" />
+  <rect x="288" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="0.65" />
+  <text x="328.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
+  <rect x="372" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(89, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="enable-meaningful-choices" data-score="0.83" />
+  <text x="412.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
+  <rect x="456" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="0.88" />
+  <text x="496.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
+  <rect x="540" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.80" />
+  <text x="580.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
+  <rect x="624" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="foster-healthy-relationships" data-score="0.89" />
+  <text x="664.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <rect x="708" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
+  <text x="748.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="792" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(99, 197, 69)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="be-transparent-and-honest" data-score="0.76" />
+  <text x="832.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.76</text>
+  <rect x="876" y="306" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.85" />
+  <text x="916.0" y="321.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.85</text>
+  <text x="0" y="355.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.0 Flash 001</text>
+  <rect x="180" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="HumaneScore" data-score="0.82" />
   <text x="220.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
-  <rect x="288" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="respect-user-attention" data-score="0.65" />
-  <text x="328.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
-  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(88, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="enable-meaningful-choices" data-score="0.83" />
-  <text x="412.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
-  <rect x="456" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="enhance-human-capabilities" data-score="0.88" />
-  <text x="496.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
-  <rect x="540" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="protect-dignity-and-safety" data-score="0.80" />
-  <text x="580.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
-  <rect x="624" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="foster-healthy-relationships" data-score="0.89" />
-  <text x="664.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
-  <text x="748.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(98, 197, 69)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="be-transparent-and-honest" data-score="0.76" />
-  <text x="832.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.76</text>
-  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4.1" data-principle-id="design-for-equity-and-inclusion" data-score="0.84" />
-  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
-  <text x="0" y="389.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Flash</text>
-  <rect x="180" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="HumaneScore" data-score="0.77" />
+  <rect x="288" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(119, 201, 63)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="respect-user-attention" data-score="0.61" />
+  <text x="328.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.61</text>
+  <rect x="372" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="enable-meaningful-choices" data-score="0.86" />
+  <text x="412.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
+  <rect x="456" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="enhance-human-capabilities" data-score="0.92" />
+  <text x="496.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="540" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(83, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="protect-dignity-and-safety" data-score="0.87" />
+  <text x="580.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
+  <rect x="624" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(77, 193, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="foster-healthy-relationships" data-score="0.91" />
+  <text x="664.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.91</text>
+  <rect x="708" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(72, 192, 77)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="prioritize-long-term-wellbeing" data-score="0.95" />
+  <text x="748.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.95</text>
+  <rect x="792" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(116, 201, 64)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="be-transparent-and-honest" data-score="0.63" />
+  <text x="832.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.63</text>
+  <rect x="876" y="340" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.0-flash-001" data-principle-id="design-for-equity-and-inclusion" data-score="0.81" />
+  <text x="916.0" y="355.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
+  <text x="0" y="389.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4o (2024-11-20)</text>
+  <rect x="180" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(96, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="HumaneScore" data-score="0.77" />
   <text x="220.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
-  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(141, 205, 57)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="0.46" />
-  <text x="328.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.46</text>
-  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="enable-meaningful-choices" data-score="0.80" />
-  <text x="412.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
-  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="enhance-human-capabilities" data-score="0.89" />
-  <text x="496.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
-  <rect x="540" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(101, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="protect-dignity-and-safety" data-score="0.74" />
+  <rect x="288" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(119, 201, 63)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="0.61" />
+  <text x="328.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.61</text>
+  <rect x="372" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="0.79" />
+  <text x="412.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
+  <rect x="456" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(76, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="0.92" />
+  <text x="496.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="540" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(100, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="protect-dignity-and-safety" data-score="0.74" />
   <text x="580.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.74</text>
-  <rect x="624" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="foster-healthy-relationships" data-score="0.87" />
-  <text x="664.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
-  <rect x="708" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
-  <text x="748.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="792" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(107, 199, 67)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="be-transparent-and-honest" data-score="0.70" />
-  <text x="832.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.70</text>
-  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(101, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="design-for-equity-and-inclusion" data-score="0.74" />
-  <text x="916.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.74</text>
-  <text x="0" y="423.0" class="font-weight-medium text-caption" dominant-baseline="middle">GPT-4o (2024-11-20)</text>
-  <rect x="180" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="HumaneScore" data-score="0.77" />
+  <rect x="624" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="foster-healthy-relationships" data-score="0.86" />
+  <text x="664.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
+  <rect x="708" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="prioritize-long-term-wellbeing" data-score="0.90" />
+  <text x="748.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
+  <rect x="792" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(128, 203, 61)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="0.55" />
+  <text x="832.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.55</text>
+  <rect x="876" y="374" width="80" height="30" rx="8" ry="8" fill="rgb(90, 196, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="0.82" />
+  <text x="916.0" y="389.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.82</text>
+  <text x="0" y="423.0" class="font-weight-medium text-caption" dominant-baseline="middle">Gemini 2.5 Flash</text>
+  <rect x="180" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 69)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="HumaneScore" data-score="0.77" />
   <text x="220.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
-  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(119, 201, 63)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="respect-user-attention" data-score="0.61" />
-  <text x="328.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.61</text>
-  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enable-meaningful-choices" data-score="0.79" />
-  <text x="412.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
-  <rect x="456" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="enhance-human-capabilities" data-score="0.92" />
-  <text x="496.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
-  <rect x="540" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(101, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="protect-dignity-and-safety" data-score="0.74" />
+  <rect x="288" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(140, 205, 57)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="respect-user-attention" data-score="0.46" />
+  <text x="328.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.46</text>
+  <rect x="372" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="enable-meaningful-choices" data-score="0.80" />
+  <text x="412.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.80</text>
+  <rect x="456" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(80, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="enhance-human-capabilities" data-score="0.89" />
+  <text x="496.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.89</text>
+  <rect x="540" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(101, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="protect-dignity-and-safety" data-score="0.74" />
   <text x="580.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.74</text>
-  <rect x="624" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="foster-healthy-relationships" data-score="0.86" />
-  <text x="664.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(78, 194, 75)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="prioritize-long-term-wellbeing" data-score="0.90" />
-  <text x="748.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.90</text>
-  <rect x="792" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(126, 202, 61)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="be-transparent-and-honest" data-score="0.56" />
-  <text x="832.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.56</text>
-  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(94, 196, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gpt-4o-2024-11-20" data-principle-id="design-for-equity-and-inclusion" data-score="0.79" />
-  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.79</text>
+  <rect x="624" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(82, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="foster-healthy-relationships" data-score="0.87" />
+  <text x="664.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.87</text>
+  <rect x="708" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(75, 193, 76)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="prioritize-long-term-wellbeing" data-score="0.92" />
+  <text x="748.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.92</text>
+  <rect x="792" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(108, 199, 66)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="be-transparent-and-honest" data-score="0.69" />
+  <text x="832.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.69</text>
+  <rect x="876" y="408" width="80" height="30" rx="8" ry="8" fill="rgb(97, 197, 69)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="gemini-2.5-flash" data-principle-id="design-for-equity-and-inclusion" data-score="0.77" />
+  <text x="916.0" y="423.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.77</text>
   <text x="0" y="457.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 3.1 405B Instruct</text>
   <rect x="180" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(109, 199, 66)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="HumaneScore" data-score="0.68" />
   <text x="220.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.68</text>
-  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(148, 206, 55)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="0.41" />
+  <rect x="288" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(147, 206, 55)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="respect-user-attention" data-score="0.41" />
   <text x="328.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.41</text>
-  <rect x="372" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(115, 200, 64)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enable-meaningful-choices" data-score="0.64" />
+  <rect x="372" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(116, 200, 64)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enable-meaningful-choices" data-score="0.64" />
   <text x="412.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.64</text>
-  <rect x="456" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(87, 195, 72)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enhance-human-capabilities" data-score="0.84" />
+  <rect x="456" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(86, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="enhance-human-capabilities" data-score="0.84" />
   <text x="496.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.84</text>
-  <rect x="540" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="protect-dignity-and-safety" data-score="0.72" />
+  <rect x="540" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 67)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="protect-dignity-and-safety" data-score="0.72" />
   <text x="580.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.72</text>
   <rect x="624" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="foster-healthy-relationships" data-score="0.88" />
   <text x="664.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
@@ -270,10 +270,10 @@
   <text x="748.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.83</text>
   <rect x="792" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(158, 208, 52)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="be-transparent-and-honest" data-score="0.34" />
   <text x="832.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.34</text>
-  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(95, 197, 70)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="design-for-equity-and-inclusion" data-score="0.78" />
-  <text x="916.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.78</text>
+  <rect x="876" y="442" width="80" height="30" rx="8" ry="8" fill="rgb(92, 196, 71)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-3.1-405b-instruct" data-principle-id="design-for-equity-and-inclusion" data-score="0.81" />
+  <text x="916.0" y="457.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.81</text>
   <text x="0" y="491.0" class="font-weight-medium text-caption" dominant-baseline="middle">LLaMA 4 Maverick</text>
-  <rect x="180" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(114, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="HumaneScore" data-score="0.65" />
+  <rect x="180" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(113, 200, 65)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="HumaneScore" data-score="0.65" />
   <text x="220.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.65</text>
   <rect x="288" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(172, 211, 48)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="respect-user-attention" data-score="0.24" />
   <text x="328.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.24</text>
@@ -285,9 +285,9 @@
   <text x="580.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.63</text>
   <rect x="624" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(81, 194, 74)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="foster-healthy-relationships" data-score="0.88" />
   <text x="664.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.88</text>
-  <rect x="708" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(84, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="prioritize-long-term-wellbeing" data-score="0.86" />
+  <rect x="708" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(83, 195, 73)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="prioritize-long-term-wellbeing" data-score="0.86" />
   <text x="748.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.86</text>
-  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(152, 207, 54)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="0.38" />
+  <rect x="792" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(151, 207, 54)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="be-transparent-and-honest" data-score="0.38" />
   <text x="832.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.38</text>
   <rect x="876" y="476" width="80" height="30" rx="8" ry="8" fill="rgb(104, 198, 68)" class="score-cell cursor-pointer" data-dataset="good_persona" data-model="llama-4-maverick" data-principle-id="design-for-equity-and-inclusion" data-score="0.72" />
   <text x="916.0" y="491.0" class="font-weight-bold text-caption" text-anchor="middle" dominant-baseline="middle">0.72</text>

--- a/scripts/create_scoregrid_svg.py
+++ b/scripts/create_scoregrid_svg.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 """
-Generate static ScoreGrid SVGs from eval_results headers.
+Generate static ScoreGrid SVGs from canonical post-exclusion score CSVs.
 
-This mirrors the layout/color rules in humanebench-website/src/components/ScoreGrid.vue
-so the site can embed SVGs without bundling the raw eval data. Each cell includes
-data-* attributes to make it easy to reattach hover tooltips client-side.
+Reads <dataset>_scores.csv at the repo root (produced by extract_all_scores.py,
+which honors humanebench.excluded.load_excluded_ids), so the SVGs stay in lockstep
+with model_scores.json on the website. Mirrors the layout/color rules in
+humanebench-website/src/components/ScoreGrid.vue. Each cell includes data-*
+attributes to make it easy to reattach hover tooltips client-side.
 """
 
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -77,38 +80,26 @@ def score_to_color(score: float) -> str:
     return f"rgb({r}, {g}, {b})"
 
 
-def load_models(data_dir: Path, dataset: str) -> Dict[str, Dict[str, float]]:
-    """Return model -> metric values dict for a dataset by reading zipped .eval logs."""
+def load_models(csv_dir: Path, dataset: str) -> Dict[str, Dict[str, float]]:
+    """Return model -> metric values dict for a dataset by reading the canonical
+    post-exclusion <dataset>_scores.csv at csv_dir."""
+    csv_path = csv_dir / f"{dataset}_scores.csv"
+    if not csv_path.exists():
+        print(f"[warn] {csv_path} not found, skipping {dataset}")
+        return {}
+
+    principle_ids = [p["id"] for p in PRINCIPLES if p["id"] != "HumaneScore"]
     models: Dict[str, Dict[str, float]] = {}
-    dataset_dir = data_dir / dataset
-    if not dataset_dir.exists():
-        return models
-
-    for eval_file in sorted(dataset_dir.rglob("*.eval")):
-        # Expect logs/<dataset>/<model>/<timestamp>.eval
-        relative_parts = eval_file.relative_to(dataset_dir).parts
-        if len(relative_parts) < 2:
-            continue
-        model_key = relative_parts[0]
-
-        try:
-            import zipfile
-
-            with zipfile.ZipFile(eval_file) as zf:
-                with zf.open("header.json") as header_fp:
-                    payload = json.load(header_fp)
-        except Exception as exc:  # pragma: no cover - defensive
-            print(f"[warn] Skipping {eval_file}: {exc}")
-            continue
-
-        metrics = payload["results"]["scores"][0]["metrics"]
-        models[model_key] = {k: v.get("value", 0) for k, v in metrics.items()}
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            metrics = {"HumaneScore": float(row["overall"])}
+            for pid in principle_ids:
+                metrics[pid] = float(row[pid])
+            models[row["model"]] = metrics
 
     def sort_key(item: tuple[str, Dict[str, float]]) -> tuple[float, str]:
         model_key, metrics = item
-        score = metrics.get("HumaneScore", 0.0)
-        # Sort by HumaneScore desc, then model key asc for stability.
-        return (-score, model_key)
+        return (-metrics.get("HumaneScore", 0.0), model_key)
 
     return OrderedDict(sorted(models.items(), key=sort_key))
 
@@ -227,19 +218,19 @@ def build_svg(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate static ScoreGrid SVGs from eval_results headers.",
+        description="Generate static ScoreGrid SVGs from canonical post-exclusion score CSVs.",
     )
     parser.add_argument(
         "datasets",
         nargs="*",
         default=["bad_persona", "good_persona", "baseline"],
-        help="Dataset folders under eval_results to render.",
+        help="Datasets to render. Each maps to <dataset>_scores.csv in --csv-dir.",
     )
     parser.add_argument(
-        "--data-dir",
+        "--csv-dir",
         type=Path,
-        default=Path(__file__).resolve().parent.parent / "logs",
-        help="Path to the logs directory (contains task folders like bad_persona/good_persona/baseline).",
+        default=Path(__file__).resolve().parent.parent,
+        help="Directory containing baseline_scores.csv / good_persona_scores.csv / bad_persona_scores.csv (default: repo root).",
     )
     parser.add_argument(
         "--output-dir",
@@ -276,7 +267,7 @@ def main() -> None:
     model_map_out.write_text(json.dumps(model_map, indent=2))
 
     for dataset in args.datasets:
-        models = load_models(args.data_dir, dataset)
+        models = load_models(args.csv_dir, dataset)
         if not models:
             print(f"[warn] No models found for dataset '{dataset}', skipping.")
             continue

--- a/scripts/export_model_scores_json.py
+++ b/scripts/export_model_scores_json.py
@@ -1,0 +1,107 @@
+"""Export per-model, per-principle scores to the website's model_scores.json shape.
+
+Reads canonical post-exclusion CSVs (baseline_scores.csv, good_persona_scores.csv,
+bad_persona_scores.csv) and writes JSON consumed by the humanebench-website
+ScoreGrid / ScoreCarousel / ModelDetailPage components. displayName and provider
+fields are preserved from the existing JSON so they stay single-sourced there.
+"""
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PRINCIPLES = [
+    "respect-user-attention",
+    "enable-meaningful-choices",
+    "enhance-human-capabilities",
+    "protect-dignity-and-safety",
+    "foster-healthy-relationships",
+    "prioritize-long-term-wellbeing",
+    "be-transparent-and-honest",
+    "design-for-equity-and-inclusion",
+]
+
+PERSONAS = {
+    "baseline": "baseline_scores.csv",
+    "good_persona": "good_persona_scores.csv",
+    "bad_persona": "bad_persona_scores.csv",
+}
+
+
+def round2(x: float) -> float:
+    # Round to 2 decimals; round() returns float and json.dumps renders cleanly.
+    return round(float(x), 2)
+
+
+def load_scores(csv_path: Path) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    with csv_path.open() as f:
+        for row in csv.DictReader(f):
+            model = row["model"]
+            entry = {"HumaneScore": round2(row["overall"])}
+            for p in PRINCIPLES:
+                entry[p] = round2(row[p])
+            out[model] = entry
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT.parent / "humanebench-website" / "public" / "data" / "model_scores.json",
+        help="Destination JSON path (default: ../humanebench-website/public/data/model_scores.json)",
+    )
+    ap.add_argument(
+        "--csv-dir",
+        type=Path,
+        default=REPO_ROOT,
+        help="Directory containing the per-persona score CSVs (default: repo root)",
+    )
+    args = ap.parse_args()
+
+    if not args.output.exists():
+        raise SystemExit(
+            f"Existing JSON not found at {args.output}; cannot read displayName/provider."
+        )
+
+    existing = json.loads(args.output.read_text())
+    existing_models = existing.get("models", {})
+
+    persona_scores = {
+        persona: load_scores(args.csv_dir / fname) for persona, fname in PERSONAS.items()
+    }
+
+    # Use the model set present in baseline (canonical) and intersect with the existing JSON
+    # so we keep ordering and surface any drift (added/removed models).
+    csv_models = set(persona_scores["baseline"].keys())
+    json_models = set(existing_models.keys())
+    missing_in_csv = json_models - csv_models
+    missing_in_json = csv_models - json_models
+    if missing_in_csv:
+        print(f"WARNING: models in JSON but missing from CSVs: {sorted(missing_in_csv)}")
+    if missing_in_json:
+        print(f"WARNING: models in CSVs but missing from JSON: {sorted(missing_in_json)}")
+
+    out_models: dict[str, dict] = {}
+    for model_id, meta in existing_models.items():
+        if model_id not in csv_models:
+            # Preserve untouched (won't happen in practice but avoids accidental data loss).
+            out_models[model_id] = meta
+            continue
+        out_models[model_id] = {
+            "displayName": meta.get("displayName", model_id),
+            "provider": meta.get("provider", ""),
+            "scores": {persona: persona_scores[persona][model_id] for persona in PERSONAS},
+        }
+
+    args.output.write_text(json.dumps({"models": out_models}, indent=2) + "\n")
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_figures_to_website.sh
+++ b/scripts/publish_figures_to_website.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Publish figures from this repo to the website repo.
+# Publish figures and per-model score JSON from this repo to the website repo.
 # Usage: ./scripts/publish_figures_to_website.sh [website-repo-path]
 
 WEBSITE_REPO=${1:-"../humanebench-website"}
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIGURES_SRC="${SRC_DIR}/figures"
 FIGURES_DST="${WEBSITE_REPO}/public/figures"
+SCORES_DST="${WEBSITE_REPO}/public/data/model_scores.json"
 
 if [[ ! -d "${WEBSITE_REPO}" ]]; then
   echo "Website repo not found at ${WEBSITE_REPO}" >&2
@@ -23,4 +24,8 @@ echo "Publishing figures from ${FIGURES_SRC} to ${FIGURES_DST}"
 rm -rf "${FIGURES_DST}"
 mkdir -p "${FIGURES_DST}"
 cp -a "${FIGURES_SRC}/." "${FIGURES_DST}/"
+
+echo "Regenerating ${SCORES_DST} from canonical CSVs"
+python3 "${SRC_DIR}/scripts/export_model_scores_json.py" --output "${SCORES_DST}"
+
 echo "Done."


### PR DESCRIPTION
## Summary
- Adds `scripts/export_model_scores_json.py`, which reads the canonical post-exclusion per-persona CSVs (`baseline_scores.csv`, `good_persona_scores.csv`, `bad_persona_scores.csv`) and emits the JSON shape consumed by the humanebench-website ScoreGrid / ScoreCarousel / ModelDetailPage components.
- `displayName` and `provider` are pulled from the existing destination JSON so model metadata stays single-sourced on the website side.
- Extends `scripts/publish_figures_to_website.sh` to also invoke the new exporter, so a single command refreshes both figures and scores on the sister repo.

## Test plan
- [ ] `./scripts/publish_figures_to_website.sh` runs cleanly with default sibling-repo path
- [ ] Resulting `humanebench-website/public/data/model_scores.json` parses and matches canonical CSVs at 2-decimal precision (verified: 405/405 cells match)
- [ ] Re-running the script produces no diff (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)