### PR TITLE
Remind dashboard step that the venv must be active

### DIFF
--- a/evaluator/workshop/README.md
+++ b/evaluator/workshop/README.md
@@ -155,8 +155,13 @@ principle so you can see where they agree and where they don't.
 Goal: visualize everything in `results.jsonl` as a one-page Streamlit app.
 
 ```bash
+# from evaluator/workshop/, with the venv from step 0 activated:
 streamlit run dashboard.py
 ```
+
+If you opened a new terminal since step 0, re-activate the venv first
+(`source ../.venv/bin/activate`). The dashboard reads `./results.jsonl`
+by default; you can point it at a different file from the sidebar.
 
 Open the URL it prints. The sidebar lets you filter by **judge model** and
 **principle**; the rest of the page reacts to those filters.


### PR DESCRIPTION
## Summary

Tiny README fix to `evaluator/workshop/README.md` step 3. The README's step 0 sets up a venv but step 3 (the streamlit command) gives no signal that the venv setup needs to carry forward. Anyone returning to the dashboard in a fresh terminal hits "command not found" with no obvious fix in the doc.

This adds an explicit re-activation note plus the relative path from `workshop/` back to the venv.

## Test plan

- [ ] Open a fresh terminal, `cd evaluator/workshop`, follow the doc
- [ ] Confirm `source ../.venv/bin/activate` followed by `streamlit run dashboard.py` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)