### PR TITLE
F11/F2/F3: version the schema, key score rows by what they judge

### DIFF
--- a/cli/src/judge/mod.rs
+++ b/cli/src/judge/mod.rs
@@ -259,6 +259,11 @@ pub fn assemble_turn_prompt(turn: &ScorableTurn) -> String {
 /// `content_hash` covers the exact bytes sent to the judge — assembled prompt, rubric
 /// text (which the prompt contains), and judge model id — so a rubric revision or a model
 /// swap correctly invalidates rather than silently serving stale scores.
+///
+/// It answers "what would this call cost?", not "which score is this?". Two different
+/// turns can assemble to the same bytes — the same short exchange in two sessions — and
+/// they share a hash while remaining two separate scores. Which rows may coexist is
+/// decided by `(identity, tier, judge_model)` in the store, never by this value.
 pub fn content_hash(prompt: &str, judge_model: &str) -> String {
     let mut hasher = blake3::Hasher::new();
     hasher.update(prompt.as_bytes());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -295,9 +295,123 @@ fn cmd_ingest(
     Ok(())
 }
 
+/// One judge call and every score row it will produce.
+///
+/// Subjects share a job when their assembled prompts are byte-identical. That happens for
+/// real: "thanks" answered "You're welcome!" in two different sessions assembles to the
+/// same bytes, and both turns deserve a score even though only one call is warranted.
+struct Job<T> {
+    prompt: String,
+    hash: String,
+    subjects: Vec<T>,
+    /// A judgement the store already holds for these exact bytes. When it is present the
+    /// rows are filled from it and nothing is sent — the prompt has already been paid for.
+    reuse: Option<judge::Judgement>,
+}
+
+impl<T> Job<T> {
+    fn needs_a_call(&self) -> bool {
+        self.reuse.is_none()
+    }
+}
+
 struct Plan {
-    turns: Vec<(transcript::ScorableTurn, String, String)>,
-    rollups: Vec<(transcript::Session, String, String)>,
+    turns: Vec<Job<transcript::ScorableTurn>>,
+    rollups: Vec<Job<transcript::Session>>,
+}
+
+/// Jobs that would cost a call.
+fn pending_calls<T>(jobs: &[Job<T>]) -> usize {
+    jobs.iter().filter(|j| j.needs_a_call()).count()
+}
+
+/// Estimated input tokens for the jobs that would cost a call.
+fn pending_tokens<T>(jobs: &[Job<T>]) -> usize {
+    jobs.iter()
+        .filter(|j| j.needs_a_call())
+        .map(|j| judge::estimate_tokens(&j.prompt))
+        .sum()
+}
+
+impl Plan {
+    /// What a run would actually spend.
+    fn calls(&self) -> usize {
+        pending_calls(&self.turns) + pending_calls(&self.rollups)
+    }
+
+    /// Rows a run would write. Never fewer than [`Plan::calls`], and more whenever the
+    /// corpus repeats itself.
+    fn rows(&self) -> usize {
+        self.turns.iter().map(|j| j.subjects.len()).sum::<usize>()
+            + self.rollups.iter().map(|j| j.subjects.len()).sum::<usize>()
+    }
+}
+
+/// Add a subject to the plan, folding it into an existing job when another subject has
+/// already produced these exact bytes.
+fn enqueue<T>(
+    jobs: &mut Vec<Job<T>>,
+    by_hash: &mut BTreeMap<String, usize>,
+    store: &Store,
+    prompt: String,
+    hash: String,
+    subject: T,
+) -> Result<()> {
+    if let Some(&i) = by_hash.get(&hash) {
+        jobs[i].subjects.push(subject);
+        return Ok(());
+    }
+    let reuse = store.judgement_for_hash(&hash)?;
+    by_hash.insert(hash.clone(), jobs.len());
+    jobs.push(Job {
+        prompt,
+        hash,
+        subjects: vec![subject],
+        reuse,
+    });
+    Ok(())
+}
+
+/// The stable identity of a session's rollup row — see [`store::rollup_identity`].
+fn rollup_identity_of(session: &transcript::Session) -> String {
+    store::rollup_identity(
+        &session.session_id,
+        session.started_at().unwrap_or_else(Utc::now),
+    )
+}
+
+/// The session as the rollup judge is shown it: labelled with the thread root rather than
+/// the sub-session number.
+///
+/// `assemble_rollup_prompt` prints the session id as context, so the positional `#N` that
+/// `sessionize` assigns lands inside the hashed bytes. The first idle-gap split of a
+/// thread renames `sA` to `sA#1`, and a chunk whose content has not changed by a single
+/// character re-hashes and is billed all over again. Labelling every chunk with the
+/// thread root keeps those bytes stable across the split. Nothing is lost: the id is
+/// context the prompt itself calls "not itself scored", and the sub-session number is
+/// what the row's `session_id` column records.
+fn as_rollup_subject(session: &transcript::Session) -> transcript::Session {
+    transcript::Session {
+        session_id: store::thread_root(&session.session_id).to_string(),
+        source: session.source.clone(),
+        records: session.records.clone(),
+    }
+}
+
+/// A rollup row is stamped at the *end* of the arc it judges, not the start.
+///
+/// `score --since T` rolls a straddling session up whole, so a session that began long
+/// before `T` can be judged entirely because of turns after it. Stamping that row at the
+/// session start put it outside the very window that selected it, and `report --since T`
+/// then filtered out the rollup just paid for. The last instant the arc covers is always
+/// inside the window that selected the session.
+fn rollup_timestamp(session: &transcript::Session) -> DateTime<Utc> {
+    session
+        .records
+        .last()
+        .map(|r| r.timestamp)
+        .or_else(|| session.started_at())
+        .unwrap_or_else(Utc::now)
 }
 
 /// Work out what still needs judging. Cache hits never appear here.
@@ -318,6 +432,10 @@ fn build_plan(
 
     let mut turns = Vec::new();
     let mut rollups = Vec::new();
+    // Deduplication runs across the whole corpus, not per session — the whole point is
+    // that the repeat lives in a *different* session.
+    let mut turns_by_hash = BTreeMap::new();
+    let mut rollups_by_hash = BTreeMap::new();
 
     for session in sessions {
         // Sessionizing and prompt-pairing both run over the whole corpus first: the
@@ -334,16 +452,25 @@ fn build_plan(
             for turn in in_window {
                 let prompt = judge::assemble_turn_prompt(&turn);
                 let hash = judge::content_hash(&prompt, judge_model);
-                if !store.has_score(&hash)? {
-                    turns.push((turn, prompt, hash));
+                if store.is_scored(&turn.turn_id, Tier::Turn, judge_model, &hash)? {
+                    continue;
                 }
+                enqueue(&mut turns, &mut turns_by_hash, store, prompt, hash, turn)?;
             }
         }
         if (tier == "both" || tier == "rollup") && worth_rolling_up {
-            let prompt = judge::rollup::assemble_rollup_prompt(&session);
+            let prompt = judge::rollup::assemble_rollup_prompt(&as_rollup_subject(&session));
             let hash = judge::content_hash(&prompt, judge_model);
-            if !store.has_score(&hash)? {
-                rollups.push((session, prompt, hash));
+            let identity = rollup_identity_of(&session);
+            if !store.is_scored(&identity, Tier::Rollup, judge_model, &hash)? {
+                enqueue(
+                    &mut rollups,
+                    &mut rollups_by_hash,
+                    store,
+                    prompt,
+                    hash,
+                    session,
+                )?;
             }
         }
     }
@@ -383,19 +510,14 @@ fn cmd_score(
     let window = since.map(|s| format!("since {}", s.format("%Y-%m-%d %H:%M UTC")));
 
     let plan = build_plan(store, &judge_model, idle_gap_hours, &tier, since)?;
-    let total = plan.turns.len() + plan.rollups.len();
+    let total = plan.calls();
+    let rows = plan.rows();
 
     if dry_run {
-        let turn_tokens: usize = plan
-            .turns
-            .iter()
-            .map(|(_, p, _)| judge::estimate_tokens(p))
-            .sum();
-        let rollup_tokens: usize = plan
-            .rollups
-            .iter()
-            .map(|(_, p, _)| judge::estimate_tokens(p))
-            .sum();
+        let turn_tokens = pending_tokens(&plan.turns);
+        let rollup_tokens = pending_tokens(&plan.rollups);
+        let turn_calls = pending_calls(&plan.turns);
+        let rollup_calls = pending_calls(&plan.rollups);
 
         println!("Judge model: {judge_model}");
         println!("Regime:      {} (single judge)", judge::REGIME);
@@ -404,14 +526,22 @@ fn cmd_score(
             None => println!("Window:      the whole pending corpus"),
         }
         println!();
-        println!("Turn-tier calls needed:   {}", plan.turns.len());
-        println!("Rollup calls needed:      {}", plan.rollups.len());
+        println!("Turn-tier calls needed:   {turn_calls}");
+        println!("Rollup calls needed:      {rollup_calls}");
         println!("Total calls:              {total}");
+        println!("Scores this would write:  {rows}");
         println!();
         println!("Estimated input tokens:   ~{}", turn_tokens + rollup_tokens);
         println!("  turn tier:              ~{turn_tokens}");
         println!("  rollups:                ~{rollup_tokens}");
         println!();
+        if rows > total {
+            println!(
+                "{} score(s) need no call of their own: the corpus repeats itself, and \n\
+                 identical text is judged once and recorded against every turn it covers.\n",
+                rows - total
+            );
+        }
         println!(
             "Token counts are a crude estimate (chars/4) and exclude output. Multiply by your \n\
              judge model's input price to get a cost. Cached turns are already excluded, so \n\
@@ -420,7 +550,7 @@ fn cmd_score(
         return Ok(());
     }
 
-    if total == 0 {
+    if rows == 0 {
         match &window {
             Some(w) => println!("Nothing pending {w} — that slice is already scored."),
             None => println!("Everything is already scored — nothing to do."),
@@ -432,112 +562,214 @@ fn cmd_score(
     // Above the consent prompt on purpose: the call count it quotes is meaningless
     // without the slice it covers.
     match &window {
-        Some(w) => println!("Scoring {total} pending item(s) {w}; everything older stays pending."),
-        None => println!("Scoring {total} pending item(s) — the whole pending corpus."),
+        Some(w) => println!("Scoring {rows} pending item(s) {w}; everything older stays pending."),
+        None => println!("Scoring {rows} pending item(s) — the whole pending corpus."),
+    }
+    if rows > total {
+        println!(
+            "{} of them repeat text already judged and will be filled from the store.",
+            rows - total
+        );
     }
 
-    let judge = Judge::new(provider, &model)?;
-    let destination = judge.destination();
-    let judge_model = judge.labelled_model();
+    // Only build a judge — and only ask for consent — if something actually has to be
+    // sent. A run that is entirely reuse must work on a machine with no credentials.
+    let judge = if total > 0 {
+        let judge = Judge::new(provider, &model)?;
+        let destination = judge.destination();
+        if !store.consent_granted(&destination)? {
+            if yes {
+                store.grant_consent(&destination)?;
+            } else if prompt_consent(&destination, judge.model(), total)? {
+                store.grant_consent(&destination)?;
+                println!("Consent recorded for {destination}. This will not be asked again.\n");
+            } else {
+                println!("No consent given. Nothing was sent and nothing was scored.");
+                return Ok(());
+            }
+        }
+        Some(judge)
+    } else {
+        None
+    };
+    let judge_model = match &judge {
+        Some(j) => j.labelled_model(),
+        None => judge_model,
+    };
 
-    if !store.consent_granted(&destination)? {
-        if yes {
-            store.grant_consent(&destination)?;
-        } else if prompt_consent(&destination, judge.model(), total)? {
-            store.grant_consent(&destination)?;
-            println!("Consent recorded for {destination}. This will not be asked again.\n");
-        } else {
-            println!("No consent given. Nothing was sent and nothing was scored.");
-            return Ok(());
+    let mut run = Run {
+        judge: judge.as_ref(),
+        cap: limit.unwrap_or(usize::MAX),
+        total,
+        calls: 0,
+        failed: 0,
+        written: 0,
+        reused: 0,
+        spent: judge::Usage::default(),
+    };
+
+    for job in &plan.turns {
+        let judgement = match run.step(job, "turn", &job.subjects[0].turn_id) {
+            Step::Judged(j) => j,
+            Step::Skip => continue,
+            Step::Stop => break,
+        };
+        for turn in &job.subjects {
+            let rec = store::score_record(
+                &turn.turn_id,
+                &turn.session_id,
+                Tier::Turn,
+                &job.hash,
+                &judge_model,
+                judge::REGIME,
+                judgement.clone(),
+            );
+            store
+                .insert_score_at(&rec, &turn.source, turn.model.as_deref(), turn.timestamp)
+                .with_context(|| format!("storing the score for turn {}", turn.turn_id))?;
+            run.written += 1;
         }
     }
 
-    let cap = limit.unwrap_or(usize::MAX);
-    let mut done = 0usize;
-    let mut failed = 0usize;
-    let mut spent = judge::Usage::default();
-
-    for (turn, prompt, hash) in &plan.turns {
-        if done >= cap {
-            break;
+    for job in &plan.rollups {
+        let judgement = match run.step(job, "rollup", &job.subjects[0].session_id) {
+            Step::Judged(j) => j,
+            Step::Skip => continue,
+            Step::Stop => break,
+        };
+        for session in &job.subjects {
+            let rec = store::score_record(
+                &format!("{}:rollup", session.session_id),
+                &session.session_id,
+                Tier::Rollup,
+                &job.hash,
+                &judge_model,
+                judge::REGIME,
+                judgement.clone(),
+            );
+            store
+                .insert_score_as(
+                    &rec,
+                    &rollup_identity_of(session),
+                    &session.source,
+                    None,
+                    rollup_timestamp(session),
+                )
+                .with_context(|| {
+                    format!(
+                        "storing the rollup score for session {}",
+                        session.session_id
+                    )
+                })?;
+            run.written += 1;
         }
-        eprint!("\r  scoring turn {}/{}…", done + 1, total.min(cap));
-        match judge_one(&judge, prompt) {
-            Ok((j, usage)) => {
-                spent.prompt_tokens += usage.prompt_tokens;
-                spent.completion_tokens += usage.completion_tokens;
-                let rec = store::score_record(
-                    &turn.turn_id,
-                    &turn.session_id,
-                    Tier::Turn,
-                    hash,
-                    &judge_model,
-                    judge::REGIME,
-                    j,
-                );
-                store
-                    .insert_score_at(&rec, &turn.source, turn.model.as_deref(), turn.timestamp)
-                    .with_context(|| format!("storing the score for turn {}", turn.turn_id))?;
-            }
-            Err(e) => {
-                failed += 1;
-                eprintln!("\n  ! turn {} failed: {e}", turn.turn_id);
-            }
-        }
-        done += 1;
-    }
-
-    for (session, prompt, hash) in &plan.rollups {
-        if done >= cap {
-            break;
-        }
-        eprint!("\r  scoring rollup {}/{}…", done + 1, total.min(cap));
-        match judge_one(&judge, prompt) {
-            Ok((j, usage)) => {
-                spent.prompt_tokens += usage.prompt_tokens;
-                spent.completion_tokens += usage.completion_tokens;
-                let rec = store::score_record(
-                    &format!("{}:rollup", session.session_id),
-                    &session.session_id,
-                    Tier::Rollup,
-                    hash,
-                    &judge_model,
-                    judge::REGIME,
-                    j,
-                );
-                let ts = session.started_at().unwrap_or_else(Utc::now);
-                store
-                    .insert_score_at(&rec, &session.source, None, ts)
-                    .with_context(|| {
-                        format!(
-                            "storing the rollup score for session {}",
-                            session.session_id
-                        )
-                    })?;
-            }
-            Err(e) => {
-                failed += 1;
-                eprintln!("\n  ! rollup {} failed: {e}", session.session_id);
-            }
-        }
-        done += 1;
     }
 
     eprintln!("\r                                          ");
-    println!("Scored {} of {total} pending item(s).", done - failed);
-    if failed > 0 {
-        println!("{failed} failed and were not cached; re-run to retry just those.");
+    println!(
+        "Scored {} pending item(s) in {} judge call(s).",
+        run.written,
+        run.calls - run.failed
+    );
+    if run.reused > 0 {
+        println!(
+            "{} of them reused a judgement already in the store — no call, no cost.",
+            run.reused
+        );
+    }
+    if run.failed > 0 {
+        println!(
+            "{} call(s) failed and were not cached; re-run to retry just those.",
+            run.failed
+        );
     }
     // The real number, as reported by the API — not the crude dry-run estimate.
-    if spent.prompt_tokens > 0 || spent.completion_tokens > 0 {
+    if run.spent.prompt_tokens > 0 || run.spent.completion_tokens > 0 {
         println!(
             "Tokens actually used: {} input + {} output. Multiply by your judge model's \
              prices for the real cost of this run.",
-            spent.prompt_tokens, spent.completion_tokens
+            run.spent.prompt_tokens, run.spent.completion_tokens
         );
     }
+    // A run in which nothing survived is a failed run, and must not exit 0.
+    score_outcome(run.calls, run.failed)?;
     println!("\nNext: `humanebench report --out report.html`");
     Ok(())
+}
+
+/// Whether a completed `score` run counts as a success.
+///
+/// A partial failure stays a success: the scores that landed are real, they are cached,
+/// and the printout says to re-run for the rest. A run where every single call failed has
+/// nothing to show and almost always means a bad key, no network, or a wrong model id —
+/// exiting 0 there reports success to a script that has just scored nothing.
+fn score_outcome(calls: usize, failed: usize) -> Result<()> {
+    if calls > 0 && failed == calls {
+        bail!(
+            "every judge call failed ({failed} of {calls}) — nothing was scored. Check the \
+             API key, the network, and the --model id, then re-run."
+        );
+    }
+    Ok(())
+}
+
+/// What a job produced.
+enum Step {
+    /// Record this judgement against every subject of the job.
+    Judged(judge::Judgement),
+    /// This job failed. Nothing is recorded for it and the run carries on.
+    Skip,
+    /// The `--limit` budget is spent.
+    Stop,
+}
+
+/// The running totals of one `score` invocation.
+struct Run<'a> {
+    judge: Option<&'a Judge>,
+    cap: usize,
+    total: usize,
+    calls: usize,
+    failed: usize,
+    written: usize,
+    reused: usize,
+    spent: judge::Usage,
+}
+
+impl Run<'_> {
+    /// The judgement for one job: the one the store already holds for these bytes, or a
+    /// fresh call.
+    fn step<T>(&mut self, job: &Job<T>, label: &str, subject: &str) -> Step {
+        if let Some(j) = &job.reuse {
+            self.reused += job.subjects.len();
+            return Step::Judged(j.clone());
+        }
+        if self.calls >= self.cap {
+            return Step::Stop;
+        }
+        // `total > 0` is what built the judge, and `total` counts exactly the jobs that
+        // reach this line — so this is unreachable rather than a silent no-op.
+        let Some(judge) = self.judge else {
+            return Step::Stop;
+        };
+        eprint!(
+            "\r  scoring {label} {}/{}…",
+            self.calls + 1,
+            self.total.min(self.cap)
+        );
+        self.calls += 1;
+        match judge_one(judge, &job.prompt) {
+            Ok((j, usage)) => {
+                self.spent.prompt_tokens += usage.prompt_tokens;
+                self.spent.completion_tokens += usage.completion_tokens;
+                Step::Judged(j)
+            }
+            Err(e) => {
+                self.failed += 1;
+                eprintln!("\n  ! {label} {subject} failed: {e}");
+                Step::Skip
+            }
+        }
+    }
 }
 
 fn judge_one(judge: &Judge, prompt: &str) -> Result<(judge::Judgement, judge::Usage)> {
@@ -820,6 +1052,366 @@ mod tests {
         DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
     }
 
+    fn a_judgement() -> judge::Judgement {
+        judge::Judgement {
+            principles: judge::PRINCIPLES
+                .iter()
+                .map(|n| judge::PrincipleScore {
+                    name: n.to_string(),
+                    score: 0.5,
+                    rationale: None,
+                })
+                .collect(),
+            global_violations: vec![],
+            confidence: 0.8,
+        }
+    }
+
+    /// Record a judgement for everything in a plan, exactly the way `cmd_score` does —
+    /// same identities, same timestamps, one judgement fanned out over every subject of a
+    /// job. Tests that reach into the store by hand instead would not prove the caching
+    /// they claim to.
+    fn pay_for(store: &Store, plan: &Plan, judge_model: &str) {
+        for job in &plan.turns {
+            for turn in &job.subjects {
+                let rec = store::score_record(
+                    &turn.turn_id,
+                    &turn.session_id,
+                    Tier::Turn,
+                    &job.hash,
+                    judge_model,
+                    judge::REGIME,
+                    a_judgement(),
+                );
+                store
+                    .insert_score_at(&rec, &turn.source, turn.model.as_deref(), turn.timestamp)
+                    .unwrap();
+            }
+        }
+        for job in &plan.rollups {
+            for session in &job.subjects {
+                let rec = store::score_record(
+                    &format!("{}:rollup", session.session_id),
+                    &session.session_id,
+                    Tier::Rollup,
+                    &job.hash,
+                    judge_model,
+                    judge::REGIME,
+                    a_judgement(),
+                );
+                store
+                    .insert_score_as(
+                        &rec,
+                        &rollup_identity_of(session),
+                        &session.source,
+                        None,
+                        rollup_timestamp(session),
+                    )
+                    .unwrap();
+            }
+        }
+    }
+
+    fn turn_ids_in(plan: &Plan) -> Vec<&str> {
+        plan.turns
+            .iter()
+            .flat_map(|j| j.subjects.iter().map(|t| t.turn_id.as_str()))
+            .collect()
+    }
+
+    fn rollup_ids_in(plan: &Plan) -> Vec<&str> {
+        plan.rollups
+            .iter()
+            .flat_map(|j| j.subjects.iter().map(|s| s.session_id.as_str()))
+            .collect()
+    }
+
+    fn turn_hash(plan: &Plan, turn_id: &str) -> String {
+        plan.turns
+            .iter()
+            .find(|j| j.subjects.iter().any(|t| t.turn_id == turn_id))
+            .map(|j| j.hash.clone())
+            .unwrap()
+    }
+
+    fn rollup_hash(plan: &Plan, session_id: &str) -> String {
+        plan.rollups
+            .iter()
+            .find(|j| j.subjects.iter().any(|s| s.session_id == session_id))
+            .map(|j| j.hash.clone())
+            .unwrap()
+    }
+
+    fn exchange(session: &str, n: &str, prompt: &str, reply: &str, at: &str) -> Vec<Record> {
+        let at = ts(at);
+        vec![
+            Record::new(
+                "claude-code",
+                session,
+                format!("u{n}"),
+                Role::User,
+                prompt,
+                at,
+            ),
+            Record::new(
+                "claude-code",
+                session,
+                format!("a{n}"),
+                Role::Assistant,
+                reply,
+                at + Duration::minutes(1),
+            ),
+        ]
+    }
+
+    // ---- F2: identical turns in different sessions --------------------------
+
+    /// Two sessions containing the same exchange assemble to the same bytes. One judge
+    /// call is right; one score row is not — the second turn would be billed for and then
+    /// be invisible to every report.
+    #[test]
+    fn identical_turns_in_two_sessions_are_one_call_and_two_scores() {
+        let mut store = Store::open_in_memory().unwrap();
+        let mut recs = exchange(
+            "sA",
+            "1",
+            "thanks",
+            "You're welcome!",
+            "2026-01-01T00:00:00Z",
+        );
+        recs.extend(exchange(
+            "sB",
+            "2",
+            "thanks",
+            "You're welcome!",
+            "2026-03-01T00:00:00Z",
+        ));
+        store.upsert_records(&recs).unwrap();
+
+        let plan = build_plan(&store, "m", 6, "turn", None).unwrap();
+        assert_eq!(
+            plan.turns.len(),
+            1,
+            "byte-identical prompts must collapse to a single judge call"
+        );
+        assert_eq!(plan.calls(), 1);
+        assert_eq!(
+            plan.rows(),
+            2,
+            "…and still produce a score for each of the two turns"
+        );
+        assert_eq!(turn_ids_in(&plan), ["a1", "a2"]);
+
+        pay_for(&store, &plan, "m");
+
+        let scored = store.scores(&Filter::default()).unwrap();
+        let ids: Vec<&str> = scored.iter().map(|s| s.record.turn_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            ["a1", "a2"],
+            "both turns must reach the report, not just the first one seen"
+        );
+        assert_eq!(
+            scored[0].record.content_hash, scored[1].record.content_hash,
+            "they share a content hash — that is what made them one call"
+        );
+
+        // And a second run must not re-judge either of them.
+        assert_eq!(build_plan(&store, "m", 6, "turn", None).unwrap().calls(), 0);
+    }
+
+    /// The same exchange appearing later, after the first was already paid for, costs
+    /// nothing: the judgement is already in the store.
+    #[test]
+    fn a_repeat_of_an_already_judged_exchange_costs_no_call() {
+        let mut store = Store::open_in_memory().unwrap();
+        store
+            .upsert_records(&exchange(
+                "sA",
+                "1",
+                "thanks",
+                "You're welcome!",
+                "2026-01-01T00:00:00Z",
+            ))
+            .unwrap();
+        let plan = build_plan(&store, "m", 6, "turn", None).unwrap();
+        pay_for(&store, &plan, "m");
+
+        store
+            .upsert_records(&exchange(
+                "sB",
+                "2",
+                "thanks",
+                "You're welcome!",
+                "2026-03-01T00:00:00Z",
+            ))
+            .unwrap();
+        let plan = build_plan(&store, "m", 6, "turn", None).unwrap();
+        assert_eq!(
+            turn_ids_in(&plan),
+            ["a2"],
+            "the new turn still needs a score"
+        );
+        assert_eq!(
+            plan.calls(),
+            0,
+            "but not a judge call — these exact bytes have already been paid for"
+        );
+        assert_eq!(plan.rows(), 1);
+
+        pay_for(&store, &plan, "m");
+        assert_eq!(store.scores(&Filter::default()).unwrap().len(), 2);
+    }
+
+    // ---- F3: rollups supersede ----------------------------------------------
+
+    /// Score, ingest more of the same session, re-score. The session must end up with one
+    /// rollup row, judged on the complete arc — not one per generation, averaged together.
+    #[test]
+    fn re_scoring_a_grown_session_leaves_one_rollup_carrying_the_latest_arc() {
+        let mut store = Store::open_in_memory().unwrap();
+        store
+            .upsert_records(&exchange(
+                "sA",
+                "1",
+                "first question",
+                "first answer",
+                "2026-01-01T00:00:00Z",
+            ))
+            .unwrap();
+        let first = build_plan(&store, "m", 6, "rollup", None).unwrap();
+        assert_eq!(first.calls(), 1);
+        pay_for(&store, &first, "m");
+        let first_hash = rollup_hash(&first, "sA");
+
+        // More of the same conversation arrives.
+        store
+            .upsert_records(&exchange(
+                "sA",
+                "2",
+                "second question",
+                "second answer",
+                "2026-01-01T00:30:00Z",
+            ))
+            .unwrap();
+        let second = build_plan(&store, "m", 6, "rollup", None).unwrap();
+        assert_eq!(
+            second.calls(),
+            1,
+            "the arc grew, so it genuinely needs re-judging"
+        );
+        assert_ne!(rollup_hash(&second, "sA"), first_hash);
+        pay_for(&store, &second, "m");
+
+        let rollups = store
+            .scores(&Filter {
+                tier: Some(Tier::Rollup),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            rollups.len(),
+            1,
+            "one rollup per session — the stub arc must not linger and be averaged in"
+        );
+        assert_eq!(
+            rollups[0].record.content_hash,
+            rollup_hash(&second, "sA"),
+            "the surviving row must be the one judged on the complete arc"
+        );
+    }
+
+    /// An idle gap renames `sA` to `sA#1`. The unchanged chunk must neither be re-billed
+    /// nor leave its pre-rename rollup behind as a row nothing can supersede.
+    #[test]
+    fn an_idle_gap_split_neither_rebills_nor_orphans_the_first_chunk() {
+        let mut store = Store::open_in_memory().unwrap();
+        store
+            .upsert_records(&exchange(
+                "sA",
+                "1",
+                "first question",
+                "first answer",
+                "2026-01-01T00:00:00Z",
+            ))
+            .unwrap();
+        let before = build_plan(&store, "m", 6, "rollup", None).unwrap();
+        assert_eq!(rollup_ids_in(&before), ["sA"]);
+        pay_for(&store, &before, "m");
+
+        // A week later the same thread resumes: `sessionize` now splits it in two, and
+        // the first chunk is renumbered `sA#1`.
+        store
+            .upsert_records(&exchange(
+                "sA",
+                "2",
+                "much later question",
+                "much later answer",
+                "2026-01-08T00:00:00Z",
+            ))
+            .unwrap();
+        let after = build_plan(&store, "m", 6, "rollup", None).unwrap();
+        assert_eq!(rollup_ids_in(&after), ["sA#2"], "only the new chunk is new");
+        pay_for(&store, &after, "m");
+
+        let rollups = store
+            .scores(&Filter {
+                tier: Some(Tier::Rollup),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            rollups.len(),
+            2,
+            "two chunks, two rollups — the renamed one must not become a third"
+        );
+    }
+
+    // ---- F18: a rollup survives the window that selected it -------------------
+
+    /// `score --since T` rolls a straddling session up whole. `report --since T` must then
+    /// still show it: paying for a rollup the same window hides is a broken round trip.
+    #[test]
+    fn a_rollup_survives_the_since_window_that_paid_for_it() {
+        let store = straddling_store();
+        let cutoff = ts("2026-01-01T01:00:00Z");
+
+        let plan = build_plan(&store, "m", 6, "both", Some(cutoff)).unwrap();
+        assert_eq!(rollup_ids_in(&plan), ["s1"]);
+        pay_for(&store, &plan, "m");
+
+        let visible = store
+            .scores(&Filter {
+                since: Some(cutoff),
+                tier: Some(Tier::Rollup),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            rollup_ids_in(&plan).len(),
+            visible.len(),
+            "every rollup the window billed for must be visible through the same window"
+        );
+        assert_eq!(visible[0].record.session_id, "s1");
+    }
+
+    // ---- F23: a run that scored nothing is not a success ----------------------
+
+    #[test]
+    fn a_run_where_every_call_failed_is_an_error() {
+        // A bad API key fails every call. Exiting 0 there tells a script the corpus is
+        // scored when not one score was written.
+        assert!(score_outcome(4, 4).is_err());
+        assert!(
+            score_outcome(4, 1).is_ok(),
+            "a partial failure still scored"
+        );
+        assert!(
+            score_outcome(0, 0).is_ok(),
+            "an all-cache run made no calls"
+        );
+    }
+
     /// With nothing to discover, the error has to carry every route forward: where it
     /// looked, and the two ways to ingest that don't rely on discovery at all.
     #[test]
@@ -893,43 +1485,8 @@ mod tests {
         assert_eq!(plan.turns.len(), 1);
         assert_eq!(plan.rollups.len(), 1);
 
-        // Cache both, then the plan must be empty.
-        let judgement = judge::Judgement {
-            principles: judge::PRINCIPLES
-                .iter()
-                .map(|n| judge::PrincipleScore {
-                    name: n.to_string(),
-                    score: 0.5,
-                    rationale: None,
-                })
-                .collect(),
-            global_violations: vec![],
-            confidence: 0.8,
-        };
-        for (_, _, hash) in &plan.turns {
-            let rec = store::score_record(
-                "a1",
-                "s1",
-                Tier::Turn,
-                hash,
-                "openrouter/m",
-                "single",
-                judgement.clone(),
-            );
-            store.insert_score(&rec, "claude-code", None).unwrap();
-        }
-        for (_, _, hash) in &plan.rollups {
-            let rec = store::score_record(
-                "s1:rollup",
-                "s1",
-                Tier::Rollup,
-                hash,
-                "openrouter/m",
-                "single",
-                judgement.clone(),
-            );
-            store.insert_score(&rec, "claude-code", None).unwrap();
-        }
+        // Pay for both, then the plan must be empty.
+        pay_for(&store, &plan, "openrouter/m");
 
         let plan2 = build_plan(&store, "openrouter/m", 6, "both", None).unwrap();
         assert_eq!(
@@ -964,30 +1521,7 @@ mod tests {
         store.upsert_records(&recs).unwrap();
 
         let plan = build_plan(&store, "openrouter/model-a", 6, "both", None).unwrap();
-        let judgement = judge::Judgement {
-            principles: judge::PRINCIPLES
-                .iter()
-                .map(|n| judge::PrincipleScore {
-                    name: n.to_string(),
-                    score: 0.5,
-                    rationale: None,
-                })
-                .collect(),
-            global_violations: vec![],
-            confidence: 0.8,
-        };
-        for (_, _, hash) in &plan.turns {
-            let rec = store::score_record(
-                "a1",
-                "s1",
-                Tier::Turn,
-                hash,
-                "openrouter/model-a",
-                "single",
-                judgement.clone(),
-            );
-            store.insert_score(&rec, "claude-code", None).unwrap();
-        }
+        pay_for(&store, &plan, "openrouter/model-a");
 
         let plan_b = build_plan(&store, "openrouter/model-b", 6, "turn", None).unwrap();
         assert_eq!(
@@ -1103,18 +1637,10 @@ mod tests {
         assert_eq!(all.rollups.len(), 2);
 
         let windowed = build_plan(&store, "m", 6, "both", Some(cutoff)).unwrap();
-        let turn_ids: Vec<&str> = windowed
-            .turns
-            .iter()
-            .map(|(t, _, _)| t.turn_id.as_str())
-            .collect();
+        let turn_ids = turn_ids_in(&windowed);
         assert_eq!(turn_ids, ["a2"]);
 
-        let rollup_ids: Vec<&str> = windowed
-            .rollups
-            .iter()
-            .map(|(s, _, _)| s.session_id.as_str())
-            .collect();
+        let rollup_ids = rollup_ids_in(&windowed);
         assert_eq!(
             rollup_ids,
             ["s1"],
@@ -1131,64 +1657,14 @@ mod tests {
         let windowed =
             build_plan(&store, "m", 6, "both", Some(ts("2026-01-01T01:00:00Z"))).unwrap();
 
-        let hash_of = |plan: &Plan, id: &str| {
-            plan.turns
-                .iter()
-                .find(|(t, _, _)| t.turn_id == id)
-                .map(|(_, _, h)| h.clone())
-                .unwrap()
-        };
-        assert_eq!(hash_of(&all, "a2"), hash_of(&windowed, "a2"));
-
-        let rollup_hash_of = |plan: &Plan, id: &str| {
-            plan.rollups
-                .iter()
-                .find(|(s, _, _)| s.session_id == id)
-                .map(|(_, _, h)| h.clone())
-                .unwrap()
-        };
-        assert_eq!(rollup_hash_of(&all, "s1"), rollup_hash_of(&windowed, "s1"));
+        assert_eq!(turn_hash(&all, "a2"), turn_hash(&windowed, "a2"));
+        assert_eq!(rollup_hash(&all, "s1"), rollup_hash(&windowed, "s1"));
 
         // Pay for the narrow window, then widen it: the overlap must not come back.
-        let judgement = judge::Judgement {
-            principles: judge::PRINCIPLES
-                .iter()
-                .map(|n| judge::PrincipleScore {
-                    name: n.to_string(),
-                    score: 0.5,
-                    rationale: None,
-                })
-                .collect(),
-            global_violations: vec![],
-            confidence: 0.8,
-        };
-        for (turn, _, hash) in &windowed.turns {
-            let rec = store::score_record(
-                &turn.turn_id,
-                &turn.session_id,
-                Tier::Turn,
-                hash,
-                "m",
-                "single",
-                judgement.clone(),
-            );
-            store.insert_score(&rec, "claude-code", None).unwrap();
-        }
-        for (session, _, hash) in &windowed.rollups {
-            let rec = store::score_record(
-                &format!("{}:rollup", session.session_id),
-                &session.session_id,
-                Tier::Rollup,
-                hash,
-                "m",
-                "single",
-                judgement.clone(),
-            );
-            store.insert_score(&rec, "claude-code", None).unwrap();
-        }
+        pay_for(&store, &windowed, "m");
 
         let widened = build_plan(&store, "m", 6, "both", None).unwrap();
-        assert!(widened.turns.iter().all(|(t, _, _)| t.turn_id != "a2"));
-        assert!(widened.rollups.iter().all(|(s, _, _)| s.session_id != "s1"));
+        assert!(!turn_ids_in(&widened).contains(&"a2"));
+        assert!(!rollup_ids_in(&widened).contains(&"s1"));
     }
 }

--- a/cli/src/store/mod.rs
+++ b/cli/src/store/mod.rs
@@ -1,16 +1,27 @@
 //! Local SQLite store: turns, scores, and the content-hash cache.
 //!
 //! The cache is the reason a given turn crosses the trust boundary at most once, ever.
-//! `content_hash` is the primary key on `scores`, so re-running `score` after a rubric
-//! revision or a model swap correctly re-judges, while re-running it unchanged spends
-//! nothing.
+//! `content_hash` covers the exact bytes sent to the judge, so re-running `score` after a
+//! rubric revision or a model swap correctly re-judges while re-running it unchanged
+//! spends nothing.
+//!
+//! `content_hash` is deliberately *not* what identifies a row. Two different turns can
+//! produce byte-identical prompts — "thanks" answered "You're welcome!" in two sessions —
+//! and both deserve a score. A row is identified by `(identity, tier, judge_model)`
+//! instead: what was judged, at which tier, by which model. That is also what makes a
+//! rollup supersede rather than accumulate when its arc grows.
 
 use crate::judge::{Judgement, PrincipleScore, ScoreRecord, Tier};
 use crate::transcript::{Action, Record, Role};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::path::{Path, PathBuf};
+
+/// The schema this build understands. Bump it and add a step to [`Store::migrate`]
+/// whenever the schema changes — an existing user database is otherwise left on the old
+/// shape, and the change silently does nothing for everyone who already has one.
+pub const SCHEMA_VERSION: i64 = 2;
 
 pub struct Store {
     conn: Connection,
@@ -52,26 +63,76 @@ impl Store {
         }
         let conn = Connection::open(path)
             .with_context(|| format!("opening store at {}", path.display()))?;
-        let store = Store { conn };
-        store.migrate()?;
+        let mut store = Store { conn };
+        store
+            .migrate()
+            .with_context(|| format!("migrating the store at {}", path.display()))?;
         Ok(store)
     }
 
     #[cfg(test)]
     pub fn open_in_memory() -> Result<Store> {
-        let store = Store {
+        let mut store = Store {
             conn: Connection::open_in_memory()?,
         };
         store.migrate()?;
         Ok(store)
     }
 
-    fn migrate(&self) -> Result<()> {
-        self.conn.execute_batch(
-            r#"
-            PRAGMA journal_mode = WAL;
-            PRAGMA foreign_keys = ON;
+    /// The schema version this database is currently on.
+    pub fn schema_version(&self) -> Result<i64> {
+        Ok(self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))?)
+    }
 
+    /// `PRAGMA user_version` lives in the database header, so setting it inside a
+    /// transaction commits and rolls back with everything else the step did. A step that
+    /// is interrupted therefore leaves the version it started at and is simply retried.
+    fn stamp_version(tx: &rusqlite::Transaction<'_>, v: i64) -> Result<()> {
+        // PRAGMA takes no bound parameters; `v` is an i64 this module chose, not input.
+        tx.execute_batch(&format!("PRAGMA user_version = {v}"))?;
+        Ok(())
+    }
+
+    /// Bring the database up to [`SCHEMA_VERSION`], one numbered step at a time.
+    ///
+    /// A database written before versioning existed reports `user_version = 0`, which is
+    /// also what a brand-new file reports — so step 1 is written to be correct for both:
+    /// it only creates what is missing. Every later step must assume it is running
+    /// against real user data that has already been paid for.
+    fn migrate(&mut self) -> Result<()> {
+        self.conn
+            .execute_batch("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;")?;
+
+        let mut version = self.schema_version()?;
+        if version > SCHEMA_VERSION {
+            bail!(
+                "this store was written by a newer humanebench (schema v{version}; this \
+                 build understands v{SCHEMA_VERSION}). Upgrade humanebench, or point --db \
+                 at a different file."
+            );
+        }
+
+        if version < 1 {
+            self.migrate_to_v1()?;
+            version = 1;
+        }
+        if version < 2 {
+            self.migrate_to_v2()?;
+            version = 2;
+        }
+
+        debug_assert_eq!(version, SCHEMA_VERSION, "migrate must reach SCHEMA_VERSION");
+        Ok(())
+    }
+
+    /// v1: the original shape. `IF NOT EXISTS` throughout, because this also runs against
+    /// pre-versioning databases that already have every one of these objects.
+    fn migrate_to_v1(&mut self) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        tx.execute_batch(
+            r#"
             CREATE TABLE IF NOT EXISTS turns (
                 turn_id     TEXT PRIMARY KEY,
                 session_id  TEXT NOT NULL,
@@ -87,7 +148,6 @@ impl Store {
             CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
             CREATE INDEX IF NOT EXISTS idx_turns_ts      ON turns(timestamp);
 
-            -- content_hash is the primary key: that IS the cache.
             CREATE TABLE IF NOT EXISTS scores (
                 content_hash      TEXT PRIMARY KEY,
                 turn_id           TEXT NOT NULL,
@@ -103,10 +163,6 @@ impl Store {
                 model             TEXT,
                 timestamp         TEXT NOT NULL
             );
-            CREATE INDEX IF NOT EXISTS idx_scores_turn    ON scores(turn_id);
-            CREATE INDEX IF NOT EXISTS idx_scores_session ON scores(session_id);
-            CREATE INDEX IF NOT EXISTS idx_scores_ts      ON scores(timestamp);
-            CREATE INDEX IF NOT EXISTS idx_scores_tier    ON scores(tier);
 
             CREATE TABLE IF NOT EXISTS meta (
                 key   TEXT PRIMARY KEY,
@@ -114,7 +170,118 @@ impl Store {
             );
             "#,
         )?;
+        Self::stamp_version(&tx, 1)?;
+        tx.commit()?;
         Ok(())
+    }
+
+    /// v2: a score row is identified by what it judged, not by the bytes it judged.
+    ///
+    /// SQLite cannot drop a primary key in place, so `scores` is rebuilt. The copy keys
+    /// each row exactly the way the runtime will, and keeps the newest when the old table
+    /// already holds several for one subject — which is exactly what a database that has
+    /// been ingested and re-scored a few times contains.
+    fn migrate_to_v2(&mut self) -> Result<()> {
+        let existing = self.v1_score_rows()?;
+        let tx = self.conn.transaction()?;
+        tx.execute_batch(
+            r#"
+            CREATE TABLE scores_v2 (
+                identity          TEXT NOT NULL,
+                tier              TEXT NOT NULL,
+                judge_model       TEXT NOT NULL,
+                content_hash      TEXT NOT NULL,
+                turn_id           TEXT NOT NULL,
+                session_id        TEXT NOT NULL,
+                regime            TEXT NOT NULL,
+                scored_at         TEXT NOT NULL,
+                principles        TEXT NOT NULL,
+                global_violations TEXT NOT NULL,
+                confidence        REAL NOT NULL,
+                source            TEXT NOT NULL DEFAULT '',
+                model             TEXT,
+                timestamp         TEXT NOT NULL,
+                PRIMARY KEY (identity, tier, judge_model)
+            );
+            "#,
+        )?;
+        {
+            let mut stmt = tx.prepare(&score_upsert_sql("scores_v2"))?;
+            for row in &existing {
+                stmt.execute(params![
+                    row.identity,
+                    row.tier,
+                    row.judge_model,
+                    row.content_hash,
+                    row.turn_id,
+                    row.session_id,
+                    row.regime,
+                    row.scored_at,
+                    row.principles,
+                    row.global_violations,
+                    row.confidence,
+                    row.source,
+                    row.model,
+                    row.timestamp,
+                ])?;
+            }
+        }
+        tx.execute_batch(
+            r#"
+            DROP TABLE scores;
+            ALTER TABLE scores_v2 RENAME TO scores;
+            CREATE INDEX IF NOT EXISTS idx_scores_turn    ON scores(turn_id);
+            CREATE INDEX IF NOT EXISTS idx_scores_session ON scores(session_id);
+            CREATE INDEX IF NOT EXISTS idx_scores_ts      ON scores(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_scores_tier    ON scores(tier);
+            CREATE INDEX IF NOT EXISTS idx_scores_hash    ON scores(content_hash);
+            "#,
+        )?;
+        Self::stamp_version(&tx, 2)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Read the v1 `scores` table, oldest judgement first, tagging each row with the
+    /// identity it will be keyed on. Oldest-first means a later duplicate overwrites an
+    /// earlier one during the copy, so a session that accumulated several rollups keeps
+    /// the one judged on the most complete arc.
+    fn v1_score_rows(&self) -> Result<Vec<V1ScoreRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT content_hash, turn_id, session_id, tier, judge_model, regime, scored_at,
+                    principles, global_violations, confidence, source, model, timestamp
+             FROM scores ORDER BY scored_at, content_hash",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            let tier: String = r.get(3)?;
+            let turn_id: String = r.get(1)?;
+            let session_id: String = r.get(2)?;
+            let timestamp: String = r.get(12)?;
+            // v1 stamped a rollup with the session's start instant, which is precisely
+            // what its identity is built from.
+            let identity = if tier == "rollup" {
+                rollup_identity_raw(&session_id, &timestamp)
+            } else {
+                turn_id.clone()
+            };
+            Ok(V1ScoreRow {
+                identity,
+                tier,
+                judge_model: r.get(4)?,
+                content_hash: r.get(0)?,
+                turn_id,
+                session_id,
+                regime: r.get(5)?,
+                scored_at: r.get(6)?,
+                principles: r.get(7)?,
+                global_violations: r.get(8)?,
+                confidence: r.get(9)?,
+                source: r.get(10)?,
+                model: r.get(11)?,
+                timestamp,
+            })
+        })?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
     }
 
     // ---- consent -------------------------------------------------------------
@@ -248,14 +415,56 @@ impl Store {
 
     // ---- scores / cache ------------------------------------------------------
 
-    /// The cache check. A hit means these exact bytes were already judged.
-    pub fn has_score(&self, content_hash: &str) -> Result<bool> {
+    /// The cache check: does this subject already carry a score produced from these exact
+    /// bytes?
+    ///
+    /// Keyed on the subject as well as the bytes. Asking only "were these bytes judged?"
+    /// is what made a second, byte-identical turn read as already-scored and never get a
+    /// row of its own — it was billed and then thrown away.
+    pub fn is_scored(
+        &self,
+        identity: &str,
+        tier: Tier,
+        judge_model: &str,
+        content_hash: &str,
+    ) -> Result<bool> {
         let n: i64 = self.conn.query_row(
-            "SELECT COUNT(*) FROM scores WHERE content_hash = ?1",
-            params![content_hash],
+            "SELECT COUNT(*) FROM scores
+             WHERE identity = ?1 AND tier = ?2 AND judge_model = ?3 AND content_hash = ?4",
+            params![identity, tier.as_str(), judge_model, content_hash],
             |r| r.get(0),
         )?;
         Ok(n > 0)
+    }
+
+    /// A judgement already recorded for these exact bytes, whatever subject it was
+    /// recorded against.
+    ///
+    /// This is what keeps the promise that a given prompt crosses the trust boundary at
+    /// most once, ever: a byte-identical turn in another session is filled from the
+    /// judgement already paid for rather than sent again.
+    pub fn judgement_for_hash(&self, content_hash: &str) -> Result<Option<Judgement>> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT principles, global_violations, confidence FROM scores
+                 WHERE content_hash = ?1 LIMIT 1",
+                params![content_hash],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, f64>(2)?,
+                    ))
+                },
+            )
+            .optional()?;
+        Ok(row.map(|(principles, violations, confidence)| Judgement {
+            principles: serde_json::from_str::<Vec<PrincipleScore>>(&principles)
+                .unwrap_or_default(),
+            global_violations: serde_json::from_str::<Vec<String>>(&violations).unwrap_or_default(),
+            confidence,
+        }))
     }
 
     /// Convenience for tests: stamp the score with its own `scored_at`.
@@ -264,27 +473,45 @@ impl Store {
         self.insert_score_at(rec, source, model, rec.scored_at)
     }
 
-    /// Insert a score, stamping it with the turn's own timestamp so trends plot against
-    /// when the conversation happened, not when it was judged.
+    /// Insert a score under the identity implied by the record itself.
+    ///
+    /// `row_ts` is when the conversation happened, not when it was judged, so trends plot
+    /// against the transcript. Rollups whose session id may be renumbered by a later
+    /// idle-gap split must go through [`Store::insert_score_as`] with a stable identity
+    /// instead — see [`rollup_identity`].
     pub fn insert_score_at(
         &self,
         rec: &ScoreRecord,
         source: &str,
         model: Option<&str>,
-        turn_ts: DateTime<Utc>,
+        row_ts: DateTime<Utc>,
+    ) -> Result<()> {
+        self.insert_score_as(rec, &rec.turn_id, source, model, row_ts)
+    }
+
+    /// Insert a score, superseding whatever this subject last scored at this tier from
+    /// this judge model.
+    ///
+    /// Superseding rather than accumulating is the point: a rollup's prompt covers the
+    /// rendered session arc, which grows on every ingest, so an append-only table ends up
+    /// averaging the early, truncated arcs in with the complete one.
+    pub fn insert_score_as(
+        &self,
+        rec: &ScoreRecord,
+        identity: &str,
+        source: &str,
+        model: Option<&str>,
+        row_ts: DateTime<Utc>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO scores(content_hash, turn_id, session_id, tier, judge_model, regime,
-                                scored_at, principles, global_violations, confidence,
-                                source, model, timestamp)
-             VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
-             ON CONFLICT(content_hash) DO NOTHING",
+            &score_upsert_sql("scores"),
             params![
+                identity,
+                rec.tier.as_str(),
+                rec.judge_model,
                 rec.content_hash,
                 rec.turn_id,
                 rec.session_id,
-                rec.tier.as_str(),
-                rec.judge_model,
                 rec.regime,
                 rec.scored_at.to_rfc3339(),
                 serde_json::to_string(&rec.principles)?,
@@ -292,7 +519,7 @@ impl Store {
                 rec.confidence,
                 source,
                 model,
-                turn_ts.to_rfc3339(),
+                row_ts.to_rfc3339(),
             ],
         )?;
         Ok(())
@@ -388,6 +615,70 @@ impl Store {
         let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
         Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
     }
+}
+
+/// One row of the pre-v2 `scores` table, tagged with the identity it will be keyed on.
+struct V1ScoreRow {
+    identity: String,
+    tier: String,
+    judge_model: String,
+    content_hash: String,
+    turn_id: String,
+    session_id: String,
+    regime: String,
+    scored_at: String,
+    principles: String,
+    global_violations: String,
+    confidence: f64,
+    source: String,
+    model: Option<String>,
+    timestamp: String,
+}
+
+/// The one upsert both the runtime and the v2 migration write through, so the two can
+/// never disagree about what supersedes what.
+fn score_upsert_sql(table: &str) -> String {
+    format!(
+        "INSERT INTO {table}(identity, tier, judge_model, content_hash, turn_id, session_id,
+                             regime, scored_at, principles, global_violations, confidence,
+                             source, model, timestamp)
+         VALUES(?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)
+         ON CONFLICT(identity, tier, judge_model) DO UPDATE SET
+           content_hash=excluded.content_hash,
+           turn_id=excluded.turn_id,
+           session_id=excluded.session_id,
+           regime=excluded.regime,
+           scored_at=excluded.scored_at,
+           principles=excluded.principles,
+           global_violations=excluded.global_violations,
+           confidence=excluded.confidence,
+           source=excluded.source,
+           model=excluded.model,
+           timestamp=excluded.timestamp"
+    )
+}
+
+/// The thread a session id belongs to, with any `#N` sub-session suffix removed.
+///
+/// `transcript::sessionize` numbers sub-sessions positionally, so the suffix is a
+/// property of how the thread happens to be split *right now*: a thread that has only
+/// ever been one chunk is `sA`, and becomes `sA#1` the first time an idle gap splits it.
+/// The root is the part that does not move.
+pub fn thread_root(session_id: &str) -> &str {
+    session_id.split('#').next().unwrap_or(session_id)
+}
+
+/// The stable identity of a session's rollup row.
+///
+/// Keying the rollup on the rendered session id would strand the pre-split row as an
+/// orphan that no later run can supersede, so the key is the thread root plus the instant
+/// the chunk begins — neither of which the renumbering touches.
+pub fn rollup_identity(session_id: &str, started_at: DateTime<Utc>) -> String {
+    rollup_identity_raw(session_id, &started_at.to_rfc3339())
+}
+
+fn rollup_identity_raw(session_id: &str, started_at_rfc3339: &str) -> String {
+    format!("{}@{started_at_rfc3339}:rollup", thread_root(session_id))
 }
 
 /// A score plus the denormalized fields the report and MCP need.
@@ -491,14 +782,28 @@ mod tests {
             "single",
             judgement(),
         );
-        assert!(!s.has_score("blake3:abc").unwrap());
+        assert!(!s.is_scored("t1", Tier::Turn, "m", "blake3:abc").unwrap());
         s.insert_score(&r, "claude-code", Some("claude-opus-5"))
             .unwrap();
-        assert!(s.has_score("blake3:abc").unwrap());
-        // Re-inserting the same hash is a no-op, not a duplicate row.
+        assert!(s.is_scored("t1", Tier::Turn, "m", "blake3:abc").unwrap());
+        // Re-inserting the same subject is a supersede, not a duplicate row.
         s.insert_score(&r, "claude-code", Some("claude-opus-5"))
             .unwrap();
         assert_eq!(s.scores(&Filter::default()).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_second_turn_with_the_same_bytes_reuses_the_judgement() {
+        // The whole promise of the cache is that a given prompt crosses the trust
+        // boundary at most once, ever. A turn elsewhere in the corpus that assembles to
+        // the same bytes must be fillable from what was already paid for.
+        let s = Store::open_in_memory().unwrap();
+        assert!(s.judgement_for_hash("blake3:abc").unwrap().is_none());
+        let r = score_record("t1", "sA", Tier::Turn, "blake3:abc", "m", "s", judgement());
+        s.insert_score(&r, "claude-code", None).unwrap();
+        let reused = s.judgement_for_hash("blake3:abc").unwrap().unwrap();
+        assert_eq!(reused.principles.len(), PRINCIPLES.len());
+        assert!((reused.confidence - 0.8).abs() < 1e-9);
     }
 
     #[test]
@@ -515,8 +820,13 @@ mod tests {
         );
         s.insert_score(&r, "claude-code", None).unwrap();
         assert!(
-            !s.has_score("blake3:def").unwrap(),
-            "model/rubric swap must miss"
+            !s.is_scored("t1", Tier::Turn, "m", "blake3:def").unwrap(),
+            "a rubric revision changes the bytes, so it must miss"
+        );
+        assert!(
+            !s.is_scored("t1", Tier::Turn, "other", "blake3:abc")
+                .unwrap(),
+            "a model swap must miss"
         );
     }
 
@@ -624,6 +934,138 @@ mod tests {
     fn overall_is_the_mean_of_eight() {
         let r = score_record("t1", "s1", Tier::Turn, "h", "m", "single", judgement());
         assert!((r.overall() - 0.5).abs() < 1e-9);
+    }
+
+    // ---- F2: identical bytes, different turns -------------------------------
+
+    #[test]
+    fn two_identical_turns_in_different_sessions_are_two_rows() {
+        // "thanks" / "You're welcome!" in two sessions assembles to the same bytes, so
+        // both carry the same content hash. Storing one and dropping the other makes the
+        // second turn permanently invisible to every report.
+        let s = Store::open_in_memory().unwrap();
+        let a = score_record("t1", "sA", Tier::Turn, "h", "m", "single", judgement());
+        let b = score_record("t2", "sB", Tier::Turn, "h", "m", "single", judgement());
+        s.insert_score(&a, "claude-code", None).unwrap();
+        s.insert_score(&b, "claude-code", None).unwrap();
+        assert_eq!(
+            s.scores(&Filter::default()).unwrap().len(),
+            2,
+            "a shared content hash must not collapse two turns into one row"
+        );
+    }
+
+    // ---- F3: a rollup supersedes, it does not accumulate ---------------------
+
+    #[test]
+    fn a_regrown_arc_supersedes_the_rollup_it_replaces() {
+        // The rollup hash covers the rendered arc, which grows on every ingest. Keeping
+        // both rows means `report` averages the stub arc with the complete one.
+        let s = Store::open_in_memory().unwrap();
+        let ts = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let ident = rollup_identity("sA", ts);
+
+        let first = score_record("sA:rollup", "sA", Tier::Rollup, "h1", "m", "s", judgement());
+        s.insert_score_as(&first, &ident, "claude-code", None, ts)
+            .unwrap();
+        let second = score_record("sA:rollup", "sA", Tier::Rollup, "h2", "m", "s", judgement());
+        s.insert_score_as(&second, &ident, "claude-code", None, ts)
+            .unwrap();
+
+        let rows = s.scores(&Filter::default()).unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "one rollup row per session, not one per ingest"
+        );
+        assert_eq!(
+            rows[0].record.content_hash, "h2",
+            "the surviving row must be the one judged on the complete arc"
+        );
+    }
+
+    #[test]
+    fn an_idle_gap_split_does_not_orphan_the_rollup_it_renames() {
+        // `sessionize` numbers sub-sessions positionally, so a thread that has only ever
+        // been one chunk is `sA` and becomes `sA#1` the first time a gap splits it. The
+        // row's identity must not move with the label.
+        let started = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(
+            rollup_identity("sA", started),
+            rollup_identity("sA#1", started),
+            "renumbering a sub-session must not change which row it supersedes"
+        );
+        assert_ne!(
+            rollup_identity("sA#1", started),
+            rollup_identity("sA#2", started + chrono::Duration::days(7)),
+            "genuinely different chunks stay different rows"
+        );
+    }
+
+    // ---- F11: versioned migrations -------------------------------------------
+
+    /// Write the pre-versioning schema by hand: `user_version` unset, `content_hash` the
+    /// primary key on `scores`, no `identity` column.
+    fn write_v0_database(path: &Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE turns (
+                turn_id TEXT PRIMARY KEY, session_id TEXT NOT NULL, source TEXT NOT NULL,
+                role TEXT NOT NULL, text TEXT NOT NULL, timestamp TEXT NOT NULL,
+                parent_id TEXT, model TEXT, actions TEXT NOT NULL DEFAULT '[]',
+                sidechain INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE scores (
+                content_hash TEXT PRIMARY KEY, turn_id TEXT NOT NULL,
+                session_id TEXT NOT NULL, tier TEXT NOT NULL, judge_model TEXT NOT NULL,
+                regime TEXT NOT NULL, scored_at TEXT NOT NULL, principles TEXT NOT NULL,
+                global_violations TEXT NOT NULL, confidence REAL NOT NULL,
+                source TEXT NOT NULL DEFAULT '', model TEXT, timestamp TEXT NOT NULL
+            );
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+
+            INSERT INTO turns(turn_id, session_id, source, role, text, timestamp)
+              VALUES('t1','sA','claude-code','assistant','hello','2026-01-01T00:00:00+00:00');
+            INSERT INTO scores VALUES
+              ('h1','t1','sA','turn','m','single','2026-01-01T00:00:00+00:00',
+               '[]','[]',0.8,'claude-code','opus','2026-01-01T00:00:00+00:00'),
+              ('h2','sA:rollup','sA','rollup','m','single','2026-01-01T00:00:00+00:00',
+               '[]','[]',0.8,'claude-code',NULL,'2026-01-01T00:00:00+00:00');
+            INSERT INTO meta VALUES('consent.judge','granted');
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn migrates_a_v0_database_forward_and_keeps_its_rows() {
+        let dir = std::env::temp_dir().join(format!("hb-migrate-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("v0.db");
+        let _ = std::fs::remove_file(&path);
+        write_v0_database(&path);
+
+        let s = Store::open(&path).unwrap();
+
+        assert_eq!(s.schema_version().unwrap(), SCHEMA_VERSION);
+        assert_eq!(s.count_turns().unwrap(), 1, "ingested turns must survive");
+        let rows = s.scores(&Filter::default()).unwrap();
+        assert_eq!(rows.len(), 2, "paid-for scores must survive");
+        assert!(
+            s.consent_granted(crate::judge::openrouter::DESTINATION)
+                .unwrap(),
+            "recorded consent must survive — re-asking would be a privacy regression"
+        );
+
+        // Idempotent: opening an already-migrated store changes nothing.
+        drop(s);
+        let s = Store::open(&path).unwrap();
+        assert_eq!(s.schema_version().unwrap(), SCHEMA_VERSION);
+        assert_eq!(s.scores(&Filter::default()).unwrap().len(), 2);
+
+        drop(s);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
Addresses **F11**, **F2** and **F3** from Jack and Andalib's architecture review of #94, plus **F18** and **F23**, which are cheap and in the same files. Targets `erika/humanebench-cli`, not `main`.

`cargo test` 136/136 (was 125), `cargo clippy --all-targets` 0 warnings, `cargo fmt --check` clean.

## F11 (done first — it gates the other two)

Schema creation was `CREATE TABLE IF NOT EXISTS` with no `user_version` and no migrations table, so any schema change would have reached new users only.

Migration is now a numbered sequence. Each step stamps `user_version` **inside the same transaction as its own writes** — `PRAGMA user_version` lives in the database header, so it commits and rolls back with the step, and an interrupted migration is simply retried from the version it started at. `v0` is correct for both a brand-new file and a pre-versioning database (step 1 only creates what is missing). A store written by a newer build is refused with an explanation rather than silently misread.

**Verified on a real database**, not only in the test: a hand-written v0 file (`user_version = 0`, `content_hash` as primary key, one turn, one turn score, two rollup rows for one session, recorded consent) opened with the release binary comes out at `user_version = 2` with the turn, the turn score and the consent intact — and the two stale rollups collapsed to the newest, which is the F3 damage an existing database already carries. Re-opening changes nothing.

## F2 — cache key omits turn identity

`content_hash` was the primary key on `scores`, so two byte-identical turns in different sessions collided: both billed, one row stored, the second turn permanently invisible.

**Chose option (b)**, and it subsumes (a). Option (a) — key `(turn_id, tier, content_hash)` — stores both rows but keeps paying twice for identical bytes, which is the one invariant the whole cache exists to hold ("a given turn crosses the trust boundary at most once, ever"). It also transplants F3's disease to the turn tier: with `content_hash` in the key, a rubric revision *accumulates* a second row for the same turn instead of superseding it, and `report::aggregate` averages both.

So the row key is `(identity, tier, judge_model)` — *what* was judged — and `content_hash` keeps its real job of answering "what would this call cost?". Concretely:

- `is_scored(identity, tier, judge_model, content_hash)` replaces `has_score(content_hash)`. Asking only "were these bytes judged?" is exactly what made the second turn read as already-scored.
- `build_plan` groups subjects sharing a hash into one `Job` and fans the single judgement out over all of them — **dedupe within the in-flight plan**, as required.
- A repeat whose judgement is *already in the store* costs no call at all (`judgement_for_hash`). Without this the fix would trade "billed and lost" for "billed again", which is not obviously better.
- A run that is entirely reuse no longer builds a judge or asks for consent, so it works with no credentials.

Reproduced end-to-end with the release binary — two sessions, same `thanks` / `You're welcome!` exchange:

```
Turn-tier calls needed:   1
Total calls:              1
Scores this would write:  2
```

## F3 — rollups append rather than supersede

The rollup prompt covers the rendered session arc, which grows on every ingest, so each ingest-then-score cycle added another row and `report::aggregate` weighted the early, truncated arcs equally with the complete one. The new key makes a fresh rollup supersede its predecessor, and the v2 migration collapses the duplicates an existing database has already accumulated (oldest-first copy, newest wins).

**The renaming half of F3 is confirmed, not misdiagnosed** — and I nearly filed it as a false positive before testing it. `assemble_rollup_prompt` prints ``session `{session_id}` `` as context, so the positional `#N` that `sessionize` assigns is inside the hashed bytes: the first idle-gap split renames `sA` to `sA#1` and re-bills a chunk whose content has not changed by one character. Measured hashes for the identical chunk before and after a split: `blake3:5607f7e…` → `blake3:b7af291…`.

Stable sub-session ids belong in `transcript::sessionize`, which is a sibling's file, so this is handled at my boundary instead and gets the same result:

- the rollup **subject** is labelled with the thread root, so the hashed bytes do not move when the numbering does (the id is context the prompt itself calls "not itself scored"; the sub-session number is what the row's `session_id` column records);
- the row's **identity** is the thread root plus the chunk's start instant, so the pre-split row is superseded rather than orphaned.

One-time cost worth flagging: a thread that is *already* split re-bills its rollups once on upgrade, because the label changes from `sA#1` to `sA`. That buys never re-billing on any future split. A proper `sessionize` fix (suffix every chunk, or key on start time) would make this unnecessary — worth doing in the file that owns it.

## F18 / F23

- **F18**: a rollup is stamped at the **end** of the arc it judges rather than the start, so a straddling session selected by `score --since T` survives `report --since T`. Neither complicated the above.
- **F23**: `score` exits non-zero when **every** call failed. Partial failure stays exit 0 deliberately — the scores that landed are real and cached, and the printout already says to re-run for the rest; failing a 500-turn run on one flaky call would be worse. The all-failed case is the one that reports success with nothing to show.

## Tests (one per finding)

| Test | Finding |
|---|---|
| `migrates_a_v0_database_forward_and_keeps_its_rows` | F11 |
| `two_identical_turns_in_different_sessions_are_two_rows` | F2 (store) |
| `identical_turns_in_two_sessions_are_one_call_and_two_scores` | F2 (both in report, one call) |
| `a_repeat_of_an_already_judged_exchange_costs_no_call` | F2 (across runs) |
| `a_second_turn_with_the_same_bytes_reuses_the_judgement` | F2 (store) |
| `a_regrown_arc_supersedes_the_rollup_it_replaces` | F3 (store) |
| `re_scoring_a_grown_session_leaves_one_rollup_carrying_the_latest_arc` | F3 (score → ingest → re-score) |
| `an_idle_gap_split_neither_rebills_nor_orphans_the_first_chunk` | F3 (renaming) |
| `an_idle_gap_split_does_not_orphan_the_rollup_it_renames` | F3 (identity) |
| `a_rollup_survives_the_since_window_that_paid_for_it` | F18 |
| `a_run_where_every_call_failed_is_an_error` | F23 |

Each was watched fail first. `two_identical_turns_…` failed on behaviour (1 row, expected 2) against the unmodified store, and `an_idle_gap_split_neither_rebills_…` failed against my own first attempt — which is what surfaced the session id inside the rollup prompt.

## Known, not fixed (out of scope, flagging)

A turn scored before its thread was split keeps the pre-split `session_id` in its row, because the turn prompt does not contain the session id and so is correctly a cache hit. Its rollup will say `sA#1` while the turn rows say `sA`. Pre-existing; would need a row refresh on ingest, or stable ids in `sessionize`.

## Files touched

`cli/src/store/mod.rs`, `cli/src/main.rs`, and the content-hash doc comment in `cli/src/judge/mod.rs`. Nothing in `transcript/`, `adapters/`, `report/`, `rubric/`, or the `PRINCIPLES` block.

<!-- sparkle:retro {"tldr":"Versioned the CLI store schema, then re-keyed score rows by what they judge so identical turns both store on one judge call and rollups supersede instead of accumulating.","percentComplete":100,"estCompletionMin":0,"details":["F11 done first: user_version migrations stamped inside each step's own transaction; verified on a real v0 database with the release binary.","F2 fixed via review option (b) plus the row-key change it requires: one call, N rows, and a repeat already in the store costs no call at all.","F3 fixed by (identity, tier, judge_model) upsert; the renaming half of F3 was confirmed real by measurement, not misdiagnosed.","F18 and F23 both landed; 136 tests pass, clippy clean."],"painPoints":[{"summary":"A finding's proposed fix spanned a file owned by a sibling agent, so the clean fix was unavailable and a boundary workaround was needed.","severity":2,"recommendation":"When splitting a review across agents, split by finding AND state which files each finding's fix will actually touch, so an owner conflict is visible at dispatch rather than discovered mid-implementation.","subsystem":"multi-agent task decomposition"},{"summary":"Nearly filed a correct review finding as a false positive because the disproving detail was in a file outside the finding's cited line range.","severity":2,"recommendation":"Before reporting a finding as misdiagnosed, grep the whole call path for the claimed cause rather than only the cited lines; a measurement that contradicts the reasoning is the signal to widen the search."}]} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJ4S4eTmw5k2qg49kT2jxi
