### PR TITLE
F4 follow-ups: correct false provenance claims and two broken documented commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -96,8 +96,14 @@ export before trusting their numbers.
 Write a converter in any language that emits the documented schema:
 
 ```sh
-your-converter < logs | humanebench ingest --stdin --source yourtool
+your-converter < logs | humanebench ingest --stdin --source normalized
 ```
+
+`--source` selects the *adapter* — which input format to parse — so already-normalized JSONL
+uses `normalized`. It is an allowlist (`claude-code`, `codex`, `chatgpt`, `claude-app`,
+`hermes`, `normalized`); an invented name is rejected. The free-form origin tag is the
+`source` **field inside each record**, which is surfaced in reports and filters but never
+parsed — that is where `yourtool` belongs.
 
 ## Privacy
 

--- a/cli/rubric/README.md
+++ b/cli/rubric/README.md
@@ -80,7 +80,7 @@ systematic upward bias, not a wash.
 (`humanebench/humane_patterns.py`, documented at the repo `README.md:311` as the `--principle`
 values, and consumed by `scripts/vp_tables_and_figure.py`, `scripts/create_scoregrid_svg.py` and a
 dozen other scripts). The CLI's are snake_case abbreviations, copied from the draft at
-`evaluator/humanebench_evaluator.py:410–419` into `src/judge/mod.rs:134–143`:
+`evaluator/humanebench_evaluator.py:410–419` into `src/judge/mod.rs:140–149`:
 
 | Benchmark (canonical) | CLI |
 |---|---|

--- a/cli/src/judge/mod.rs
+++ b/cli/src/judge/mod.rs
@@ -124,9 +124,14 @@ fn truncate(s: &str, max: usize) -> String {
     format!("{}…", &s[..end])
 }
 
-/// The two slots. These are the Go template markers from the upstream evaluator; keeping
-/// them verbatim means the embedded file stays byte-identical to its source and drift is
-/// detectable by diff.
+/// The two slots, and the *only* part of the embedded prompt that is not verbatim from its
+/// source. `rubric/judge_prompt_v3.md` is a byte-identical fork of the draft template in
+/// `evaluator/humanebench_evaluator.py:49-406`, which spells these slots the Python
+/// `str.format` way — `{user_prompt}` and `{message_content}` (py lines 395 and 401). The
+/// Go-template spelling below is this CLI's own canonicalisation, chosen so the markers
+/// cannot collide with the JSON braces the prompt asks the judge to emit. Undo it, undo
+/// `str.format`'s brace doubling, and the two files diff to nothing — see
+/// `rubric/README.md`, which documents the ancestry and the divergences it carries.
 const SLOT_USER_PROMPT: &str = "{{.UserPrompt}}";
 const SLOT_MESSAGE_CONTENT: &str = "{{.MessageContent}}";
 

--- a/cli/src/judge/rollup.rs
+++ b/cli/src/judge/rollup.rs
@@ -154,6 +154,24 @@ mod tests {
         }
     }
 
+    /// `rubric_preamble` falls back to the whole rubric when the marker is absent, which is
+    /// silent. Re-deriving the prompt from the canonical rubric (see `rubric/README.md`) is
+    /// planned work, so guard the marker directly: without this, dropping it fails as an
+    /// opaque `!contains("{{.UserPrompt}}")` assertion that names no cause.
+    #[test]
+    fn the_split_marker_the_rollup_depends_on_is_present_and_unique() {
+        const MARKER: &str = "Now, evaluate the following";
+        assert_eq!(
+            RUBRIC.matches(MARKER).count(),
+            1,
+            "rollup splits the rubric on {MARKER:?}; it must appear exactly once"
+        );
+        assert!(
+            rubric_preamble().len() < RUBRIC.len(),
+            "preamble is the whole rubric — the split silently fell back"
+        );
+    }
+
     #[test]
     fn preamble_keeps_schema_but_drops_the_two_slots() {
         let p = rubric_preamble();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -893,6 +893,7 @@ a first-class citizen with no code in the binary.
 
   schema      req  Literal "humanebench.transcript/v1".
   source      req  Free-form origin tag ("codex", "chatgpt"). Surfaced, never parsed.
+                   This is the record field, not the --source flag, which names an adapter.
   session_id  req  Groups records into one thread before idle-gap splitting.
   turn_id     req  Stable and unique ACROSS RUNS. Re-running an adapter must produce the
                    same ids or the cache misses and you pay twice.
@@ -914,7 +915,10 @@ Example:
 
 Pipe it in:
 
-  your-converter < logs | humanebench ingest --stdin --source yourtool
+  your-converter < logs | humanebench ingest --stdin --source normalized
+
+--source picks the adapter, so already-normalized JSONL uses "normalized". It is an
+allowlist; an invented name is refused. Your own tag goes in each record's source field.
 
 Flattening: for tree-shaped sources, either emit parent_id and let the binary walk from
 the newest leaf to the root, or flatten yourself and emit a linear file. Both are valid;


### PR DESCRIPTION
Five small follow-ups to the F4/F5 work merged in #98, all found by re-reading and actually *running* what #98 documented. Docs, one test, no behaviour change, no content-hash impact.

Targets `erika/humanebench-cli`. #99 and #100 are merged and nothing else is open against this base.

### 1. `8cd6795` — the slot comment asserted false provenance

The doc comment on the two slot constants said they "are the Go template markers from the upstream evaluator" and that keeping them verbatim is what makes the embedded prompt byte-identical to its source. Both halves are wrong, in exactly the direction F4 was about:

- Upstream spells the slots the Python `str.format` way — `{user_prompt}` / `{message_content}` at `evaluator/humanebench_evaluator.py:395,401`. The `{{.UserPrompt}}` spelling is this CLI's own canonicalisation.
- The slots are the **only** non-verbatim part of the prompt. Byte-identity holds *after* undoing this substitution, so "keeping them verbatim" is backwards as an explanation.

### 2. `199b27b` — the documented bring-your-own-source command does not work

`cli/README.md` told converter authors to run `humanebench ingest --stdin --source yourtool`. That fails: `adapters/mod.rs:41` rejects it with `unknown source`. Found by building the release binary and ingesting a synthetic normalized transcript.

The doc conflated the `--source` **flag** (an adapter allowlist: `claude-code`, `codex`, `chatgpt`, `claude-app`, `hermes`, `normalized`) with the `source` **field inside each record**, which is the free-form tag that really is "surfaced, never parsed". Corrected to `--source normalized` and spelled out the distinction.

### 3. `711275d` — `humanebench schema` shipped the same two errors

The built-in schema help carried the identical mistakes at `main.rs:894,917`, so every converter author reading it got a command that fails. Same fix, verified against the rebuilt binary's actual output.

### 4. `18e0c29` — guard the split marker the rollup depends on

`rubric/README.md` records that re-deriving the prompt must preserve the literal `"Now, evaluate the following"`, because `rubric_preamble()` splits on it — and that function silently falls back to returning the *whole* rubric when the marker is absent. Marker loss did surface before, but only as an opaque `!contains("{{.UserPrompt}}")` assertion naming no cause.

Now asserted directly: the marker appears exactly once, and the preamble is a proper prefix. **Mutation-verified** — renaming the marker in the embedded rubric fails this test with `it must appear exactly once`; the rubric was restored clean afterwards.

### 5. `367cc4f` — a citation this branch itself invalidated

Commit 1 grew a doc comment by six lines, moving `PRINCIPLES` from `judge/mod.rs:134–143` to `140–149`, which stale-dated a citation in `rubric/README.md`. Caught by auditing all 25 line-number citations in the F4 write-up against the tree; the other 24 resolve.

### Verification, and one gap

`cargo test` — **147 passed / 0 failed** (146 + the new guard).

`cargo clippy --all-targets` — **0 warnings, 0 errors**, verified on a forced `cargo clean -p humanebench` recompile rather than a cached run.

(An earlier revision of this description said clippy had not run on commits 3–5, because a local permission rule was refusing it. That refusal was transient; clippy has since run clean across the whole branch, and this supersedes that caveat.)

I also could not smoke-test the F5 caveat in a rendered report: `report` requires cached scores and scoring needs a live judge API key. The unit test at `report/mod.rs:979` covers that text.

<!-- sparkle:retro {"tldr":"Five F4 follow-ups: corrected a doc comment asserting false provenance for the prompt slots, fixed the same broken ingest command in both the README and the built-in schema help, added a mutation-verified guard for the rollup split marker, and repaired a citation this branch itself stale-dated.","percentComplete":100,"estCompletionMin":0,"details":["Upstream uses Python str.format slots; the Go-template spelling is the CLI's own canonicalisation, and the slots are the one non-verbatim part of the prompt","The documented bring-your-own-source command failed against the real binary; --source is an adapter allowlist, not the free-form record tag","Same two errors shipped in humanebench schema help","Split-marker guard mutation-verified: renaming the marker fails the test with a message naming the cause","Audited all 25 line-number citations; one was stale-dated by this branch's own first commit","147 tests pass; cargo clippy --all-targets clean (0 warnings) on a forced clean recompile"],"painPoints":[{"summary":"Documentation asserted provenance and a runnable command that were both wrong, and neither was caught by the test suite because nothing executed the documented command or checked the claim against its cited source.","severity":2,"recommendation":"For CLIs whose help text and README contain copy-pasteable commands, add a smoke test that executes the documented invocation against a fixture, so a doc example that no longer works fails the suite rather than reaching users.","subsystem":"cli docs / test coverage","context":"Two independent copies of the same broken ingest command shipped, one in the README and one in the binary's own schema help."},{"summary":"A local permission rule intermittently refused cargo clippy under [Modify Shared Resources] while permitting cargo test on the same workspace; the refusal cleared on a later retry.","severity":1,"recommendation":"Allowlist read-only verification commands such as cargo clippy and cargo test, or make the refusal deterministic, so an agent holding a clippy-clean bar is not left reporting an unverifiable gap that a retry would have closed.","subsystem":"permissions / auto-mode classifier","context":"Same command refused three times across separate turns, then succeeded unchanged."}]} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5Heg7NozQmgkz5Mgu52Sb

